### PR TITLE
fix re for git

### DIFF
--- a/manage_externals/manic/repository_git.py
+++ b/manage_externals/manic/repository_git.py
@@ -44,7 +44,7 @@ class GitRepository(Repository):
 
     # match tracking reference info, return XYZ from [XYZ]
     # e.g. [origin/master]
-    RE_TRACKING = re.compile(r'\[([\w\-./]+)\]')
+    RE_TRACKING = re.compile(r'\[([\w\-./]+).*\]')
 
     def __init__(self, component_name, repo):
         """


### PR DESCRIPTION
Regex for git repo was too restricted

-    RE_TRACKING = re.compile(r'\[([\w\-./]+)\]')
+    RE_TRACKING = re.compile(r'\[([\w\-./]+).*\]')

User interface changes?: No
[ If yes, describe what changed, and steps taken to ensure backward compatibilty ]

Fixes: #24 

Testing:
  unit tests:
  system tests:
  manual testing: yes

