### PR TITLE
Add allactive aux_cime_baseline tests

### DIFF
--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -24,6 +24,22 @@
       <option name="wallclock"> 01:00 </option>
     </options>
   </test>
+  <test name="SMS_Ld2" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="aux_cime_baseline"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:30 </option>
+    </options>
+  </test>
+  <test name="SMS_N3_PM3_Ld2" grid="f19_g17" compset="BHISTWs" testmods="allactive/defaultio">
+    <machines>
+      <machine name="cheyenne" compiler="gnu" category="aux_cime_baesline"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:30 </option>
+    </options>
+  </test>
   <test name="ERR" grid="f19_g17" compset="B1850" testmods="allactive/defaultio">
     <machines>
       <machine name="edison" compiler="intel" category="prealpha"/>

--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -26,7 +26,7 @@
   </test>
   <test name="SMS_Ld2" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cime_baseline"/>
+      <machine name="cheyenne" compiler="intel" category="aux_cime_baselines"/>
     </machines>
     <options>
       <option name="wallclock"> 00:30 </option>
@@ -34,7 +34,7 @@
   </test>
   <test name="SMS_N3_PM3_Ld2" grid="f19_g17" compset="BHISTWs" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="gnu" category="aux_cime_baesline"/>
+      <machine name="cheyenne" compiler="gnu" category="aux_cime_baselines"/>
     </machines>
     <options>
       <option name="wallclock"> 00:30 </option>


### PR DESCRIPTION
Add allactive aux_cime_baseline tests.

Add SMS_Ld2.f09_g17.B1850.cheyenne_intel and SMS_N3_PM3Ld2.f19_g17.B1850Ws.cheyenne_gnu
tests to the aux_cime_baselines test category. 

User interface changes?: No


Fixes:

Testing:
  unit tests:
  system tests:
  manual testing: SMS_N3_PM3Ld2.f19_g17.B1850Ws.cheyenne_gnu.allactive-defaultio

