### PR TITLE
update externals, add optional fms FOR DISSCUSION ONLY

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -65,7 +65,7 @@ local_path = components/ww3
 required = True
 
 [fms]
-branch = master
+branch = add_cime_config
 protocol = git
 repo_url = https://github.com/jedwards4b/FMS
 local_path = libraries/FMS

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -13,7 +13,7 @@ local_path = components/cice
 required = True
 
 [cime]
-branch = master
+branch = jedwards/mom6port
 protocol = git
 repo_url = https://github.com/jedwards4b/cime
 local_path = cime

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -15,7 +15,7 @@ required = True
 [cime]
 tag = cime5.4.0-alpha.28
 protocol = git
-repo_url = https://github.com/ESMCI/cime
+repo_url = https://github.com/jedwards4b/cime
 local_path = cime
 required = True
 
@@ -74,4 +74,3 @@ required = False
 
 [externals_description]
 schema_version = 1.0.0
-

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -13,12 +13,11 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.4.0-alpha.28
+branch = master
 protocol = git
 repo_url = https://github.com/jedwards4b/cime
 local_path = cime
 required = True
-
 
 [cism]
 tag = cism2_1_50
@@ -71,6 +70,14 @@ protocol = git
 repo_url = https://github.com/ESCOMP/FMS_interface
 local_path = libraries/FMS
 externals = Externals_FMS.cfg
+required = False
+
+[mom]
+branch = master
+protocol = git
+repo_url = https://github.com/ESCOMP/MOM_interface
+local_path = components/mom
+externals = Externals_MOM.cfg
 required = False
 
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -64,6 +64,14 @@ repo_url = https://svn-ccsm-models.cgd.ucar.edu/ww3
 local_path = components/ww3
 required = True
 
+[fms]
+branch = master
+protocol = git
+repo_url = https://github.com/jedwards4b/FMS
+local_path = libraries/FMS
+required = False
+
+
 [externals_description]
 schema_version = 1.0.0
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -19,6 +19,7 @@ repo_url = https://github.com/jedwards4b/cime
 local_path = cime
 required = True
 
+
 [cism]
 tag = cism2_1_50
 protocol = git
@@ -65,10 +66,11 @@ local_path = components/ww3
 required = True
 
 [fms]
-branch = add_cime_config
+branch = master
 protocol = git
-repo_url = https://github.com/jedwards4b/FMS
+repo_url = https://github.com/ESCOMP/FMS_interface
 local_path = libraries/FMS
+externals = Externals_FMS.cfg
 required = False
 
 


### PR DESCRIPTION
Add optional FMS library from GFDL and provide tools to build with CESM 

Adds the GFDL FMS library to the build.   This requires a repo fork which I currently have in
my personal space but can move when we decide where we want it.

User interface changes?: This library is set as optional but will be needed for MOM or cam-fv3

Fixes: 

Testing:
  unit tests:
  system tests:
  manual testing: built using buildlib directly with intel on hobart, buildlib will still need to be integrated into process.   I think it would be called from the mom or cam buildlib if those components determined it was required.  

The Externals in this branch point to the FMS and cime changes necessary to add this library, when you are ready to add mom or cam fv3 I would be happy to assist you. 