### PR TITLE
New version of manage_externals

### DIFF
--- a/manage_externals/manic/checkout.py
+++ b/manage_externals/manic/checkout.py
@@ -279,8 +279,15 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
                         help='DEVELOPER: output additional debugging '
                         'information to the screen and log file.')
 
-    parser.add_argument('--no-logging', action='store_true',
-                        help='DEVELOPER: disable logging.')
+    logging_group = parser.add_mutually_exclusive_group()
+
+    logging_group.add_argument('--logging', dest='do_logging',
+                               action='store_true',
+                               help='DEVELOPER: enable logging.')
+    logging_group.add_argument('--no-logging', dest='do_logging',
+                               action='store_false', default=False,
+                               help='DEVELOPER: disable logging '
+                               '(this is the default)')
 
     if args:
         options = parser.parse_args(args)
@@ -305,7 +312,7 @@ def main(args):
     *before* executing the checkout command - i.e., the status that it
     used to determine if it's safe to proceed with the checkout.
     """
-    if not args.no_logging:
+    if args.do_logging:
         logging.basicConfig(filename=LOG_FILE_NAME,
                             format='%(levelname)s : %(asctime)s : %(message)s',
                             datefmt='%Y-%m-%d %H:%M:%S',
@@ -359,6 +366,13 @@ The following are two options for how to proceed:
 (2) Alternatively, you do not have to rely on {program_name}. Instead, you
     can manually update out-of-sync externals (labeled with 's' above)
     as described in the configuration file {config_file}.
+
+
+The external repositories labeled with '?' above are not under version
+control using the expected protocol. If you are sure you want to switch
+protocols, and you don't have any work you need to save from this
+directory, then run "rm -rf [directory]" before re-running the
+checkout_externals tool.
 """.format(program_name=program_name, config_file=args.externals)
 
             printlog('-' * 70)

--- a/manage_externals/manic/repository_svn.py
+++ b/manage_externals/manic/repository_svn.py
@@ -208,7 +208,8 @@ then rerun checkout_externals.
         try:
             xml_status = ET.fromstring(svn_output)
         except BaseException:
-            fatal_error("SVN returned invalid XML message {}".format(svn_output))
+            fatal_error(
+                "SVN returned invalid XML message {}".format(svn_output))
         xml_target = xml_status.find('./target')
         entries = xml_target.findall('./entry')
         for entry in entries:


### PR DESCRIPTION
Minor updates to manage_externals

- Explain question mark in output (https://github.com/ESMCI/manage_externals/pull/102)

- Make no-logging the default (https://github.com/ESMCI/manage_externals/pull/103)

User interface changes?: No

Fixes: None

Testing: None
  unit tests:
  system tests:
  manual testing:

