### PR TITLE
remove prefix '>' from command line documentation

### DIFF
--- a/doc/source/downloading_cesm.rst
+++ b/doc/source/downloading_cesm.rst
@@ -29,8 +29,8 @@ code:
 
 .. code-block:: console
 
-    > git clone https://github.com/ESCOMP/cesm.git my_cesm_sandbox
-    > cd my_cesm_sandbox
+    git clone https://github.com/ESCOMP/cesm.git my_cesm_sandbox
+    cd my_cesm_sandbox
 
 By default, this command places you at the head of the master branch of
 CESM repository which may include in-test development code. We recommend
@@ -39,25 +39,25 @@ To list the currently supported CESM2 release tags type:
 
 .. code-block:: console
 
-    > git tag
+    git tag
 
 To checkout a specific CESM release tag type:
 
 .. code-block:: console 
 
-    > git checkout release-cesm2.0.0
+    git checkout release-cesm2.0.0
 
 Alternatively, you can clone a release directly 
 
 .. code-block:: console
 
-    > git clone -b release-cesm2.0.0 https://github.com/ESCOMP/cesm.git my_cesm_sandbox
+    git clone -b release-cesm2.0.0 https://github.com/ESCOMP/cesm.git my_cesm_sandbox
 
 then run the **checkout_externals** script from /path/to/my_cesm_sandbox.
 
 .. code-block:: console
 
-    > ./manage_externals/checkout_externals
+    ./manage_externals/checkout_externals
 
 The **checkout_externals** script will read the configuration file called ``externals.cfg`` and
 will download all the external component models and CIME into /path/to/my_cesm_sandbox. 
@@ -68,7 +68,7 @@ To see more details regarding the checkout_externals script from the command lin
 
 .. code-block:: console
 
-    > ./manage_externals/checkout_externals --help
+    ./manage_externals/checkout_externals --help
 
 
 .. warning:: When contacting the Subversion server for the first time, you may need to accept an authentication certification.
@@ -99,7 +99,7 @@ to ensure that the checkout process is complete:
 
 .. code-block:: console
 
-    > ./manage_externals/checkout_externals -S -v
+    ./manage_externals/checkout_externals -S -v
  
 
 You should now have a complete copy of the CESM2 source code in your /path/to/my_cesm_sandbox. 

--- a/doc/source/introduction.rst
+++ b/doc/source/introduction.rst
@@ -24,8 +24,6 @@ ad hoc order.
 
     Throughout the guide, this presentation style indicates shell
     commands and options, fragments of code, namelist variables, etc.
-    Where examples from an interactive shell session are presented,
-    lines starting with '>' indicate the shell prompt.
 
 Please feel free to provide feedback to the `CESM forum <https://bb.cgd.ucar.edu/>`_ about how to improve the
 documentation. 

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -54,8 +54,8 @@ in the ``$CIMEROOT/scripts`` directory
 
 .. code-block:: console
 
-    > cd $CIMEROOT/scripts
-    > ./query_config --help
+    cd $CIMEROOT/scripts
+    ./query_config --help
 
 See the `supported component sets <http://www.cesm.ucar.edu/models/cesm2.0/cesm/compsets.html>`_,
 `supported model resolutions <http://www.cesm.ucar.edu/models/cesm2.0/cesm/grids.html>`_ and `supported
@@ -77,7 +77,7 @@ invoke **create_newcase** as follows:
 
 .. code-block:: console
 
-    > create_newcase --case $CASEROOT --compset $COMPSET --res $GRID 
+    create_newcase --case $CASEROOT --compset $COMPSET --res $GRID 
 
 If running on a new target machine, see
 `the CIME porting guide <http://esmci.github.io/cime/users_guide/porting-cime.html>`_.
@@ -95,7 +95,7 @@ cd to the ``$CASEROOT`` directory.
 
 .. code-block:: console
 
-    > cd $CASEROOT
+    cd $CASEROOT
 
 Modify settings in ``env_mach_pes.xml`` (optional). (Note: To edit any of
 the env xml files, use the `xmlchange`_ command.
@@ -105,7 +105,7 @@ Invoke the **case.setup** command.
 
 .. code-block:: console
 
-    > ./case.setup  
+    ./case.setup  
 
 
 Build the executable using the case.build command
@@ -117,7 +117,7 @@ Run the build script.
 
 .. code-block:: console
 
-    > ./case.build 
+    ./case.build 
 
 Users of the NCAR cheyenne system should consider using 
 the `qcmd <https://dailyb.cisl.ucar.edu/bulletins/cisl-adds-qcmd-script-launching-resource-intensive-compilation-jobs>`_
@@ -125,7 +125,7 @@ to compile CESM2 on a compute node as follows:
 
 .. code-block:: console
 
-    > qcmd -- ./case.build
+    qcmd -- ./case.build
 
 
 Run the case
@@ -138,7 +138,7 @@ Submit the job to the batch queue using the **case.submit** command.
 
 .. code-block:: console
 
-    > ./case.submit
+    ./case.submit
 
 When the job is complete, review the following directories and files
 


### PR DESCRIPTION
Documentation updates. 
User interface changes?: [ No/Yes ] None
Fixes: [Github issue #s] #50 



