### PR TITLE
Add a top-level cmip6 usermods directory

### DIFF
--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -337,4 +337,14 @@
       <option name="wallclock">  00:30 </option>
     </options>
   </test>
+  <test name="SMS_D_Ld1" grid="f09_g17" compset="B1850" testmods="allactive/cmip6">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">0:30</option>
+          <option name="comment">Debug test exercising the cmip6 usermods directory</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
 </testlist>

--- a/cime_config/testmods_dirs/allactive/cmip6/include_user_mods
+++ b/cime_config/testmods_dirs/allactive/cmip6/include_user_mods
@@ -1,0 +1,1 @@
+../../../usermods_dirs/cmip6

--- a/cime_config/usermods_dirs/cmip6/include_user_mods
+++ b/cime_config/usermods_dirs/cmip6/include_user_mods
@@ -1,0 +1,2 @@
+../../../components/cice/cime_config/usermods_dirs/cmip6
+../../../components/clm/cime_config/usermods_dirs/cmip6


### PR DESCRIPTION
This can be used with a create_newcase command like this:

./create_newcase --case mycase --compset B1850 --res f09_g17 \
--user-mods-dir cmip6

This should probably also include user mods for CAM and maybe others.

User interface changes?: No

Testing: Setup a test like the one added, but on my local machine;
ensured that user_nl_clm and user_nl_cice were as expected.
