### PR TITLE
Fix testing and pes layout for B1PCT and BCO2x4 compsets 

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -1117,6 +1117,40 @@
 	</rootpe>
       </pes>
 
+      <pes pesize="any" compset="CAM60%[14].+CLM.+CICE.+POP.+WW3">
+        <comment>about 6.5ypd expected</comment>
+        <ntasks>
+          <ntasks_atm>-16</ntasks_atm>
+          <ntasks_lnd>-13</ntasks_lnd>
+          <ntasks_rof>-13</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_glc>-16</ntasks_glc>
+          <ntasks_wav>-1</ntasks_wav>
+          <ntasks_cpl>-16</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>-13</rootpe_ice>
+          <rootpe_ocn>-16</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>-15</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+
       <pes pesize="any" compset="CAM.+CLM.+CICE.+POP.+SWAV">
 	<comment>about 8 ypd expected</comment>
 	<ntasks>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -1050,7 +1050,7 @@
   </grid>
   <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
     <mach name="cheyenne">
-      <pes pesize="any" compset="CAM[^%]*\d_.*CLM.+CICE.+POP.+WW3">
+      <pes pesize="any" compset="CAM\d+%(_|[^W_]*_)*CLM.+CICE.+POP.+WW3">
 	<comment>about 6.5ypd expected</comment>
 	<ntasks>
 	  <ntasks_atm>-16</ntasks_atm>
@@ -1083,6 +1083,7 @@
 	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
+
       <pes pesize="any" compset="CAM60%WC.+CLM.+CICE.+POP.+WW3">
 	<comment></comment>
 	<ntasks>
@@ -1115,40 +1116,6 @@
 	  <rootpe_wav>1116</rootpe_wav>
 	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
-      </pes>
-
-      <pes pesize="any" compset="CAM60%[14].+CLM.+CICE.+POP.+WW3">
-        <comment>about 6.5ypd expected</comment>
-        <ntasks>
-          <ntasks_atm>-16</ntasks_atm>
-          <ntasks_lnd>-13</ntasks_lnd>
-          <ntasks_rof>-13</ntasks_rof>
-          <ntasks_ice>-2</ntasks_ice>
-          <ntasks_ocn>-4</ntasks_ocn>
-          <ntasks_glc>-16</ntasks_glc>
-          <ntasks_wav>-1</ntasks_wav>
-          <ntasks_cpl>-16</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>-13</rootpe_ice>
-          <rootpe_ocn>-16</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>-15</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
       </pes>
 
       <pes pesize="any" compset="CAM.+CLM.+CICE.+POP.+SWAV">

--- a/cime_config/testmods_dirs/allactive/cmip6/include_user_mods
+++ b/cime_config/testmods_dirs/allactive/cmip6/include_user_mods
@@ -1,1 +1,2 @@
+../defaultio
 ../../../usermods_dirs/cmip6


### PR DESCRIPTION
Fix testing and pes for B1PCT and BCO2x4 compsets 

The cmip6 testmod for these compsets need to increase the frequency of the outputs in
order to pass restart tests.  ../defaultio include was added to the cmip6 testmod.

These compsets also failed to make any pes matches and were set to a bad default.  A match was
added for these compsets.
 
User interface changes?: No
[ If yes, describe what changed, and steps taken to ensure backward compatibilty ]

Fixes: [Github issue #s] And brief description of each issue.

Testing:
  unit tests:
  system tests:
  manual testing: ERS.f09_g17.BCO2x4.cheyenne_intel.allactive-cmip6
                           ERS.f09_g17.B1PCT.cheyenne_intel.allactive-cmip6
                           ERS.f09_g17.B1850.cheyenne_intel.allactive-defaultio
                           ERS.f09_g17.BW1850.cheyenne_intel.allactive-defaultio

