### PR TITLE
Fix config_pes.xml for B compsets.

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -1050,41 +1050,7 @@
   </grid>
   <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
     <mach name="cheyenne">
-      <pes pesize="any" compset="CAM.*\d[^%]_.*CLM.+CICE.+POP.+WW3">
-        <comment>about 6.5ypd expected</comment>
-        <ntasks>
-          <ntasks_atm>-16</ntasks_atm>
-          <ntasks_lnd>-13</ntasks_lnd>
-          <ntasks_rof>-13</ntasks_rof>
-          <ntasks_ice>-2</ntasks_ice>
-          <ntasks_ocn>-4</ntasks_ocn>
-          <ntasks_glc>-16</ntasks_glc>
-          <ntasks_wav>-1</ntasks_wav>
-          <ntasks_cpl>-16</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>-13</rootpe_ice>
-          <rootpe_ocn>-16</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>-15</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-
-      <pes pesize="any" compset="CAM\d+%(_|[^W_]*_)*CLM.+CICE.+POP.+WW3">
+      <pes pesize="any" compset="CAM\d+%?(_|[^W_]*_)*CLM.+CICE.+POP.+WW3">
 	<comment>about 6.5ypd expected</comment>
 	<ntasks>
 	  <ntasks_atm>-16</ntasks_atm>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -1050,6 +1050,40 @@
   </grid>
   <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
     <mach name="cheyenne">
+      <pes pesize="any" compset="CAM.*\d[^%]_.*CLM.+CICE.+POP.+WW3">
+        <comment>about 6.5ypd expected</comment>
+        <ntasks>
+          <ntasks_atm>-16</ntasks_atm>
+          <ntasks_lnd>-13</ntasks_lnd>
+          <ntasks_rof>-13</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_glc>-16</ntasks_glc>
+          <ntasks_wav>-1</ntasks_wav>
+          <ntasks_cpl>-16</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>-13</rootpe_ice>
+          <rootpe_ocn>-16</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>-15</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+
       <pes pesize="any" compset="CAM\d+%(_|[^W_]*_)*CLM.+CICE.+POP.+WW3">
 	<comment>about 6.5ypd expected</comment>
 	<ntasks>


### PR DESCRIPTION
The config_pes.xml for B compset matches not having a cam modifier was left out of PR #80.

User interface changes?: No
[ If yes, describe what changed, and steps taken to ensure backward compatibilty ]

Fixes: [Github issue #s] And brief description of each issue.

Testing:
  unit tests:
  system tests:
  manual testing: B1850, BW1850, B1PCT, BW1PCT, BCO2x4, and BWCO2x4 on cheyenne, 
                            compared env_mach_pes.xml.

