### PR TITLE
Rename BW4xCO2 test to BWCO2x4 in order to match the correct compset

### DIFF
--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -133,7 +133,7 @@
       <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-  <test name="SMS_Ld1" grid="f09_g17" compset="BW4xCO2" testmods="allactive/cmip6">
+  <test name="SMS_Ld1" grid="f09_g17" compset="BWCO2x4" testmods="allactive/cmip6">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
       <machine name="cheyenne" compiler="intel" category="bwaccm"/>


### PR DESCRIPTION
BW4xCO2 in the testlist is an invalid compset name.  It is renamed to BWCO2x4 to match
the existing compset name.  

User interface changes?: [ No/Yes ]
[ If yes, describe what changed, and steps taken to ensure backward compatibilty ]

Fixes: [Github issue #s] And brief description of each issue.

Testing:
  unit tests:
  system tests:
  manual testing:

