### PR TITLE
Fix cmip6 testmods

### DIFF
--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -195,7 +195,7 @@
       <option name="wallclock"> 00:30 </option>
     </options>
   </test>
-  <test name="ERS_Ld5" grid="f09_g17" compset="BCO2x4" testmods="allactive/defaultio">
+  <test name="ERS_Ld5" grid="f09_g17" compset="BCO2x4" testmods="allactive/cmip6">
     <machines>
       <machine name="bluewaters" compiler="pgi"   category="prebeta"/>
       <machine name="cheyenne"   compiler="intel" category="prealpha"/>
@@ -375,7 +375,7 @@
       <option name="wallclock">  00:30 </option>
     </options>
   </test>
-  <test name="SMS_D_Ld1" grid="f09_g17" compset="B1850" testmods="allactive/cmip6">
+  <test name="SMS_D_Ld1" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha">
         <options>

--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -375,7 +375,7 @@
       <option name="wallclock">  00:30 </option>
     </options>
   </test>
-  <test name="SMS_D_Ld1" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
+  <test name="SMS_D_Ld1" grid="f09_g17" compset="B1850" testmods="allactive/cmip6">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha">
         <options>


### PR DESCRIPTION
One the tests was using the cmip6 testmod that shoudn't have been.  And another test should have been using the cmip6 testmod. 

User interface changes?: [ No/Yes ]
[ If yes, describe what changed, and steps taken to ensure backward compatibilty ]

Fixes: [Github issue #s] And brief description of each issue.

Testing:
  unit tests:
  system tests:
  manual testing:

