### PR TITLE
Remove unused testmods directories

### DIFF
--- a/cime_config/testmods_dirs/allactive/cesm2dev01/include_user_mods
+++ b/cime_config/testmods_dirs/allactive/cesm2dev01/include_user_mods
@@ -1,2 +1,0 @@
-../../../usermods_dirs/b1850_cism
-../default

--- a/cime_config/testmods_dirs/allactive/cesm2dev01io/include_user_mods
+++ b/cime_config/testmods_dirs/allactive/cesm2dev01io/include_user_mods
@@ -1,2 +1,0 @@
-../../../usermods_dirs/b1850_cism
-../defaultio

--- a/cime_config/testmods_dirs/allactive/cism/oneway/README
+++ b/cime_config/testmods_dirs/allactive/cism/oneway/README
@@ -1,1 +1,0 @@
-This set of testmods turns off two-way coupling

--- a/cime_config/testmods_dirs/allactive/cism/oneway/shell_commands
+++ b/cime_config/testmods_dirs/allactive/cism/oneway/shell_commands
@@ -1,1 +1,0 @@
-./xmlchange GLC_TWO_WAY_COUPLING=FALSE

--- a/cime_config/testmods_dirs/allactive/cism/trilinos/README
+++ b/cime_config/testmods_dirs/allactive/cism/trilinos/README
@@ -1,5 +1,0 @@
-This testmods directory tests the use of the trilinos solver.
-
-Note: We also want to allow the case where cism is built using
-CISM_USE_TRILINOS=TRUE, but trilinos isn't actually chosen at runtime. However,
-for now I don't feel it's worth actually having a test of that combination.

--- a/cime_config/testmods_dirs/allactive/cism/trilinos/include_user_mods
+++ b/cime_config/testmods_dirs/allactive/cism/trilinos/include_user_mods
@@ -1,1 +1,0 @@
-../apply_to_multiinstance

--- a/cime_config/testmods_dirs/allactive/cism/trilinos/shell_commands
+++ b/cime_config/testmods_dirs/allactive/cism/trilinos/shell_commands
@@ -1,1 +1,0 @@
-./xmlchange CISM_USE_TRILINOS=TRUE

--- a/cime_config/testmods_dirs/allactive/cism/trilinos/user_nl_cism
+++ b/cime_config/testmods_dirs/allactive/cism/trilinos/user_nl_cism
@@ -1,2 +1,0 @@
-which_ho_sparse = 4
-


### PR DESCRIPTION
Just a bit of cleanup: As far as I can tell, these testmods directories are unused.

User interface changes?: No

Fixes: None

Testing: None
