### PR TITLE
Remove no-longer-needed b1850 usermods directory

### DIFF
--- a/cime_config/usermods_dirs/README
+++ b/cime_config/usermods_dirs/README
@@ -1,0 +1,2 @@
+Directories here can be included in a case via the --user-mods-dir
+argument to create_newcase, or via the CPL_USER_MODS XML variable.

--- a/cime_config/usermods_dirs/b1850/user_nl_cpl
+++ b/cime_config/usermods_dirs/b1850/user_nl_cpl
@@ -1,2 +1,0 @@
-orb_iyear=1850
-orb_iyear_align=1850


### PR DESCRIPTION
Also, put a README file under cime_config/usermods_dirs (though,
admittedly, the main purpose of doing that was so that git would keep
the usermods_dirs directory around without anything else under it).

User interface changes?: No

Fixes: #77 

Testing: none
