### PR TITLE
add L pelayout for f19 on cheyenne

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -166,6 +166,39 @@
           <rootpe_cpl>0</rootpe_cpl>
         </rootpe>
       </pes>
+      <pes pesize="L" compset="CAM.+CLM.+CICE.+POP.+">
+	<comment>about 48ypd expected</comment>
+        <ntasks>
+          <ntasks_atm>900</ntasks_atm>
+          <ntasks_lnd>360</ntasks_lnd>
+          <ntasks_rof>360</ntasks_rof>
+          <ntasks_ice>540</ntasks_ice>
+          <ntasks_ocn>480</ntasks_ocn>
+          <ntasks_glc>36</ntasks_glc>
+          <ntasks_wav>24</ntasks_wav>
+          <ntasks_cpl>900</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>3</nthrds_atm>
+          <nthrds_lnd>3</nthrds_lnd>
+          <nthrds_rof>3</nthrds_rof>
+          <nthrds_ice>3</nthrds_ice>
+          <nthrds_ocn>3</nthrds_ocn>
+          <nthrds_glc>3</nthrds_glc>
+          <nthrds_wav>3</nthrds_wav>
+          <nthrds_cpl>3</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>360</rootpe_ice>
+          <rootpe_ocn>900</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>1380</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
       <pes pesize="M3" compset="CAM.+CLM.+CICE.+POP.+">
 	<comment>For multi-instance tests</comment>
         <ntasks>


### PR DESCRIPTION
Adds a pelayout size L for the f19_g17 B case on cheyenne.   48 ypd

User interface changes?: 

Fixes: [Github issue #s] And brief description of each issue.
Testing:
  unit tests:
  system tests: PFS_PL.f19_g17.B1850.cheyenne_intel.allactive_defaultio
  manual testing:

