### PR TITLE
Remove stub wave compsets for cesm2.1

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -38,12 +38,6 @@
 
   <!-- 1850 compsets Default, Mosart, Wave for CESM2 -->
 
-
-  <compset>
-    <alias>B1850Ws</alias>
-    <lname>1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_SWAV_BGC%BDRD</lname>
-  </compset>
-
   <compset>
     <alias>B1850</alias>
     <lname>1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
@@ -109,11 +103,6 @@
   </compset>
 
   <compset>
-    <alias>BHISTWs</alias>
-    <lname>HIST_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_SWAV_BGC%BDRD</lname>
-  </compset>
-
-  <compset>
     <alias>BC5L45BGC</alias>
     <lname>2000_CAM50_CLM45%BGC_CICE_POP2_MOSART_SGLC_SWAV</lname>
   </compset>
@@ -165,12 +154,6 @@
   <compset>
     <alias>B1850G</alias>
     <lname>1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%EVOLVE_WW3_BGC%BDRD</lname>
-  </compset>
-
-  <!-- This is just needed for testing multi-instance, because WW3 currently does not support multi-instance -->
-  <compset>
-    <alias>B1850GWs</alias>
-    <lname>1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%EVOLVE_SWAV_BGC%BDRD</lname>
   </compset>
 
   <!-- Include one CISM1 compset, mainly for testing purposes, to make sure that

--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
-  <test name="ERI" grid="f09_g17" compset="B1850Ws" testmods="allactive/defaultio">
+  <test name="ERI" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
     <machines>
       <machine name="bluewaters" compiler="pgi" category="prebeta"/>
     </machines>
@@ -8,7 +8,7 @@
       <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-  <test name="ERI" grid="f09_g17" compset="B1850Ws" testmods="allactive/default">
+  <test name="ERI" grid="f09_g17" compset="B1850" testmods="allactive/default">
     <machines>
       <machine name="edison" compiler="intel" category="prebeta"/>
     </machines>
@@ -32,7 +32,7 @@
       <option name="wallclock"> 00:30 </option>
     </options>
   </test>
-  <test name="SMS_N3_PM3_Ld2" grid="f19_g17" compset="BHISTWs" testmods="allactive/defaultio">
+  <test name="SMS_N3_PM3_Ld2" grid="f19_g17" compset="BHIST" testmods="allactive/defaultio">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="aux_cime_baselines"/>
     </machines>
@@ -48,7 +48,7 @@
       <option name="wallclock"> 00:30 </option>
     </options>
   </test>
-  <test name="NCK" grid="f19_g17" compset="B1850Ws" testmods="allactive/defaultio">
+  <test name="NCK" grid="f19_g17" compset="B1850" testmods="allactive/defaultio">
     <machines>
       <machine name="edison" compiler="intel" category="prebeta"/>
     </machines>
@@ -56,7 +56,7 @@
       <option name="wallclock"> 02:00 </option>
     </options>
   </test>
-  <test name="NCK" grid="f19_g17" compset="B1850Ws" testmods="allactive/defaultiomi">
+  <test name="NCK" grid="f19_g17" compset="B1850" testmods="allactive/defaultiomi">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>
@@ -72,7 +72,7 @@
       <option name="wallclock"> 06:00 </option>
     </options>
   </test>
-  <test name="IRT" grid="f19_g17" compset="B1850Ws" testmods="allactive/defaultio">
+  <test name="IRT" grid="f19_g17" compset="B1850" testmods="allactive/defaultio">
     <machines>
       <machine name="bluewaters" compiler="pgi" category="prebeta"/>
     </machines>
@@ -80,22 +80,13 @@
        <option name="wallclock"> 00:30 </option>
     </options>
   </test>
-  <test name="IRT" grid="f09_g17" compset="B1850Ws" testmods="allactive/defaultio">
+  <test name="IRT" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
     <machines>
       <machine name="bluewaters" compiler="pgi" category="prealpha"/>
       <machine name="edison" compiler="cray" category="prealpha"/>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 00:40 </option>
-    </options>
-  </test>
-  <test name="ERS" grid="f19_g17" compset="B1850Ws" testmods="allactive/defaultio">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:25 </option>
     </options>
   </test>
   <test name="IRT" grid="f09_g17" compset="BRCP85L45BGCR" testmods="allactive/defaultio">
@@ -249,7 +240,7 @@
       <option name="wallclock"> 00:30 </option>
     </options>
   </test>
-  <test name="IRT_N3_PM3_Ld7" grid="f19_g17" compset="BHISTWs" testmods="allactive/defaultio">
+  <test name="IRT_N3_PM3_Ld7" grid="f19_g17" compset="BHIST" testmods="allactive/defaultio">
     <machines>
       <machine name="edison" compiler="intel" category="prebeta"/>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
@@ -275,14 +266,13 @@
       <option name="wallclock"> 00:30 </option>
     </options>
   </test>
-  <test name="NCK_Ld5" grid="f19_g17" compset="B1850GWs" testmods="allactive/cism/test_coupling">
+  <test name="NCK_Ld5" grid="f19_g17" compset="B1850G" testmods="allactive/cism/test_coupling">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
     </machines>
     <options>
       <option name="wallclock"> 01:30 </option>
-      <option name="comment">Needs to be B1850GWs rather than B1850G because WW3 currently does not support multi-instance</option>
     </options>
   </test>
   <test name="PET_PM" grid="f19_g17" compset="B1850" testmods="allactive/defaultiomi">


### PR DESCRIPTION
Stub wave compsets were added to be able to run multi-instance since.   At the time, WW3 didn't
support multi-instance.  WW3 supports multi-instance now, so the stub wave compsets are no 
longer needed.


User interface changes?: No


Fixes: [Github issue #s] And brief description of each issue.

Testing:
  unit tests:
  system tests:
  manual testing: NCK.f19_g17.B1850.cheyenne_intel

