### PR TITLE
Remove J1850G compset for now

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -216,14 +216,6 @@
     <lname>1850_CAM60_CLM45%SP_CICE_DOCN%SOM_MOSART_SGLC_SWAV_TEST</lname>
   </compset>
 
-  <!-- All active except data atmosphere
-       Used for spinup and testing of CISM couplings -->
-
-  <compset>
-     <alias>J1850G</alias>
-     <lname>1850_DATM%CRU_CLM50%BGC-CROP_CICE_POP2_MOSART_CISM2%EVOLVE_SWAV</lname>
-  </compset>
-
   <entries>
     <entry id="RUN_STARTDATE">
       <values>

--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -375,14 +375,6 @@
       <option name="wallclock"> 00:45 </option>
     </options>
   </test>
-  <test name="SMS_Ld5" grid="f09_g17_gl4" compset="J1850G" testmods="allactive/cism/test_coupling">
-    <machines>
-      <machine name="cheyenne" compiler="gnu" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
   <test name="SMS_Ld7" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>


### PR DESCRIPTION
This isn't working as written. Part of the problem is that the datm data
it points to aren't available. It could be updated to point to
CRUv7. However, that still leaves an issue of where to get the CO2
forcing data if we want this compset to replicate what's actually being
used for LIWG spinup work (which uses _BGC%BDRD). Rather than trying to
resolve this now, @katetc and I thought it best to just remove this
compset for the CESM2.1 release and then revisit this for a later
release.

User interface changes?: Yes
No J1850G compset

Testing: none
