### PR TITLE
Set CLM's use_init_interp=.false. for ERI f09_g17 B1850 tests

### DIFF
--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
-  <test name="ERI" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
+  <test name="ERI" grid="f09_g17" compset="B1850" testmods="allactive/defaultio_noclminterp">
     <machines>
       <machine name="bluewaters" compiler="pgi" category="prebeta"/>
     </machines>
@@ -8,7 +8,7 @@
       <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-  <test name="ERI" grid="f09_g17" compset="B1850" testmods="allactive/default">
+  <test name="ERI" grid="f09_g17" compset="B1850" testmods="allactive/defaultio_noclminterp">
     <machines>
       <machine name="edison" compiler="intel" category="prebeta"/>
     </machines>
@@ -16,7 +16,7 @@
       <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-  <test name="ERI" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
+  <test name="ERI" grid="f09_g17" compset="B1850" testmods="allactive/defaultio_noclminterp">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>

--- a/cime_config/testmods_dirs/allactive/defaultio_noclminterp/README
+++ b/cime_config/testmods_dirs/allactive/defaultio_noclminterp/README
@@ -1,0 +1,16 @@
+This testmod is designed for ERI tests of compset-grid combinations that
+set CLM's use_init_interp = .true. by default (which is done because
+this is needed for compatibility with the hybrid refcase used for that
+compset-grid combination). The problem with this setting is that, in the
+branch portion of the ERI test, CLM dies with an error message if
+use_init_interp is true:
+
+   ERROR: Can only set use_init_interp if finidat is set
+
+(because finidat is NOT set in a branch run).
+
+Currently, ERI tests do a startup run for the ref1 case, so we don't
+actually need the use_init_interp setting that we would normally need
+for this compset-grid combination. So it's safe to simply turn off
+use_init_interp for all of the cases in this ERI test.
+

--- a/cime_config/testmods_dirs/allactive/defaultio_noclminterp/README
+++ b/cime_config/testmods_dirs/allactive/defaultio_noclminterp/README
@@ -14,3 +14,11 @@ actually need the use_init_interp setting that we would normally need
 for this compset-grid combination. So it's safe to simply turn off
 use_init_interp for all of the cases in this ERI test.
 
+Note that we cannot turn off use_init_interp via user_nl_clm, because
+CLM_NAMELIST_OPTS takes precedence over user_nl_clm. We could append
+'use_init_interp=.false.' to CLM_NAMELIST_OPTS, but that would still
+leave the problem of init_interp_method: if that is set at all when
+use_init_interp=.false., then we get an error during build-namelist. So
+we need to remove the init_interp_method setting entirely; once we are
+going to the trouble of doing that, we might as well just remove
+use_init_interp, too.

--- a/cime_config/testmods_dirs/allactive/defaultio_noclminterp/include_user_mods
+++ b/cime_config/testmods_dirs/allactive/defaultio_noclminterp/include_user_mods
@@ -1,0 +1,1 @@
+../defaultio

--- a/cime_config/testmods_dirs/allactive/defaultio_noclminterp/shell_commands
+++ b/cime_config/testmods_dirs/allactive/defaultio_noclminterp/shell_commands
@@ -1,0 +1,5 @@
+# Remove any settings of use_init_interp and init_interp_method from CLM_NAMELIST_OPTS
+# (see README for rationale)
+clm_namelist_orig=`./xmlquery --value CLM_NAMELIST_OPTS`
+clm_namelist_new=`echo $clm_namelist_orig | sed -e 's/use_init_interp *= *[^ ]*//' -e 's/init_interp_method *= *[^ ]*//'`
+./xmlchange CLM_NAMELIST_OPTS="$clm_namelist_new"

--- a/cime_config/testmods_dirs/allactive/defaultio_noclminterp/user_nl_clm
+++ b/cime_config/testmods_dirs/allactive/defaultio_noclminterp/user_nl_clm
@@ -1,0 +1,1 @@
+use_init_interp = .false.

--- a/cime_config/testmods_dirs/allactive/defaultio_noclminterp/user_nl_clm
+++ b/cime_config/testmods_dirs/allactive/defaultio_noclminterp/user_nl_clm
@@ -1,1 +1,0 @@
-use_init_interp = .false.


### PR DESCRIPTION
This avoids this error in the branch run of ERI tests:

```
ERROR: Can only set use_init_interp if finidat is set
```

Currently, ERI tests do a startup run for the ref1 case, so we don't
actually need the use_init_interp setting that we would normally need
for this compset-grid combination. So it's safe to simply turn off
use_init_interp for all of the cases in this ERI test.

User interface changes?: No

Fixes: none

Testing:
  unit tests:
  system tests: ERI.f09_g17.B1850.cheyenne_intel.allactive-defaultio_noclminterp
  manual testing:

