### PR TITLE
BW1850 compset fix

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -45,7 +45,7 @@
 
   <compset>
     <alias>BW1850</alias>
-    <lname>1850_CAM60%WCTS_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_WW3</lname>
+    <lname>1850_CAM60%WCTS_CLM50%BGC-CROP_CICE_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3</lname>
   </compset>
   <compset>
     <alias>BWma1850</alias>


### PR DESCRIPTION
Fix the BW1850 compset by adding %NDEP to POP in the long name.


User interface changes?: NO
[ If yes, describe what changed, and steps taken to ensure backward compatibilty ]

Fixes: [Github issue #s] And brief description of each issue.

Testing:
  unit tests:
  system tests: SMS_Ld1.f09_g17.BW1850.cheyenne_intel.allactive-default
  manual testing:

