### PR TITLE
Add SSP5-8.5 compsets and test

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,90 @@
 ===============================================================
+Tag name: cesm2.1.1-rc.01
+Originator(s): CSEG
+Date: 3 Dec 2018
+One-line Summary: Fisrt release candidate for cesm2.1.1
+
+Component tags used for this CESM beta tag :
+
+components/cam                     https://svn-ccsm-models.cgd.ucar.edu/cam1/release_tags/cam_cesm2_1_rel_11/components/cam
+components/cice                    https://github.com/ESCOMP/CESM_CICE5/tree/cice5_20181204
+cime                               https://github.com/CESM-Development/cime/tree/cime5.6.10_cesm2_1_rel_06
+components/cism                    https://github.com/ESCOMP/cism-wrapper/tree/release-cesm2.0.04
+components/clm                     https://github.com/ESCOMP/ctsm/tree/release-clm5.0.17
+components/mosart                  https://github.com/ESCOMP/mosart/tree/release-cesm2.0.03
+components/pop                     https://svn-ccsm-models.cgd.ucar.edu/pop2/release_tags/pop2_cesm2_1_rel_n01 
+components/rtm                     https://github.com/ESCOMP/rtm/tree/release-cesm2.0.02
+
+cam
+    Francis Vitt 2019-02-05 - release_tags/cam_cesm2_1_rel_11 - components/cam (cesm2.1.1-rc.01)
+    https://svn-ccsm-models.cgd.ucar.edu/cam1/release_tags/cam_cesm2_1_rel_??
+
+    WACCM compsets
+
+    Fix to allow dry/wet mmr changes to run in debug mode.
+
+
+    Chris Fischer 2019-02-08 - release_tags/cam_cesm2_1_rel_10 - components/cam (cesm2.1.1-rc.01)
+    https://svn-ccsm-models.cgd.ucar.edu/cam1/release_tags/cam_cesm2_1_rel_10
+
+    fix the fix in gw_tend
+
+
+    Chris Fischer 2019-02-08 - release_tags/cam_cesm2_1_rel_09 - components/cam (cesm2.1.1-rc.01)
+    https://svn-ccsm-models.cgd.ucar.edu/cam1/release_tags/cam_cesm2_1_rel_09
+
+    treat all tracers as wet in gravity wave drag code
+
+
+    Chris Fischer 2019-02-08 - release_tags/cam_cesm2_1_rel_08 - components/cam (cesm2.1.1-rc.01)
+    https://svn-ccsm-models.cgd.ucar.edu/cam1/release_tags/cam_cesm2_1_rel_08
+
+    tracers as wet in vertical diffusion and clubb
+
+
+    Chris Fischer 2019-02-08 - release_tags/cam_cesm2_1_rel_07 - components/cam (cesm2.1.1-rc.01)
+    https://svn-ccsm-models.cgd.ucar.edu/cam1/release_tags/cam_cesm2_1_rel_07
+
+    tracers as wet in vertical diffusion and clubb
+
+
+    Chris Fischer 2019-02-08 - release_tags/cam_cesm2_1_rel_06 - components/cam (cesm2.1.1-rc.01)
+    https://svn-ccsm-models.cgd.ucar.edu/cam1/release_tags/cam_cesm2_1_rel_06
+
+    tracers as wet in vertical diffusion and clubb
+
+
+cice
+    David Bailey 2019-02-05 - cice5_20190204 - components/cice (cesm2.1.1-rc.01)
+    https://github.com/ESCOMP/CESM_CICE5/tags/cice5_20190204
+
+    This just fixes the option to have ice_ic set to 'none' or 'default'.
+
+
+    Chris Fischer 2019-02-08 - cice5_20190107 - components/cice (cesm2.1.1-rc.01)
+    https://github.com/ESCOMP/CESM_CICE5/tags/cice5_20190107
+
+    Fix setting of DECOMPTYPE
+
+
+clm
+    Erik Kluzek 2019-02-05 - release-clm5.0.17 - components/clm (cesm2.1.1-rc.01)
+    https://github.com/ESCOMP/ctsm/tags/release-clm5.0.17
+
+    History fields for vertically-resolved sums of soil C and N, and minor fixes
+
+
+    Erik Kluzek 2019-02-05 - release-clm5.0.16 - components/clm (cesm2.1.1-rc.01)
+    https://github.com/ESCOMP/ctsm/tags/release-clm5.0.16
+
+    PtVg and ssp_rcp future scenario options and Antarctica wetlands fix to mksurfdata, and option to dribble crop harvest XSMRPOOL flux to atmosphere
+
+
+    William Sacks 2018-12-06 - release-clm5.0.15 - components/clm (cesm2.1.1-rc.01)
+    https://github.com/ESCOMP/ctsm/tags/release-clm5.0.15
+
+    Option for rain-to-snow to immediately run off in some regions
+===============================================================
 Tag name: cesm2_1_beta01
 Originator(s): CSEG
 Date: 3 Dec 2018

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,12 +1,12 @@
 [cam]
-tag = cam_cesm2_1_rel_05/components/cam
+tag = cam_cesm2_1_rel_11/components/cam
 protocol = svn
 repo_url = https://svn-ccsm-models.cgd.ucar.edu/cam1/release_tags
 local_path = components/cam
 required = True
 
 [cice]
-tag = cice5_20181109
+tag = cice5_20190204
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CICE5
 local_path = components/cice
@@ -28,7 +28,7 @@ externals = Externals_CISM.cfg
 required = True
 
 [clm]
-tag = release-clm5.0.14
+tag = release-clm5.0.17
 protocol = git
 repo_url = https://github.com/ESCOMP/ctsm
 local_path = components/clm

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [cam]
-tag = cam_cesm2_1_rel_16/components/cam
+tag = cam_cesm2_1_rel_17/components/cam
 protocol = svn
 repo_url = https://svn-ccsm-models.cgd.ucar.edu/cam1/release_tags
 local_path = components/cam
@@ -13,7 +13,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.11
+tag = cime5.6.12
 protocol = git
 repo_url = https://github.com/ESMCI/cime
 local_path = cime

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [cam]
-tag = cam_cesm2_1_rel_15/components/cam
+tag = cam_cesm2_1_rel_16/components/cam
 protocol = svn
 repo_url = https://svn-ccsm-models.cgd.ucar.edu/cam1/release_tags
 local_path = components/cam
@@ -43,7 +43,7 @@ local_path = components/mosart
 required = True
 
 [pop]
-tag = cesm_pop_2_1_20190222
+tag = cesm_pop_2_1_20190306
 protocol = svn
 repo_url = https://svn-ccsm-models.cgd.ucar.edu/pop2/trunk_tags
 local_path = components/pop

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [cam]
-tag = cam_cesm2_1_rel_11/components/cam
+tag = cam_cesm2_1_rel_15/components/cam
 protocol = svn
 repo_url = https://svn-ccsm-models.cgd.ucar.edu/cam1/release_tags
 local_path = components/cam
@@ -13,7 +13,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_cesm2_1_rel_06
+tag = cime5.6.11
 protocol = git
 repo_url = https://github.com/ESMCI/cime
 local_path = cime
@@ -28,9 +28,9 @@ externals = Externals_CISM.cfg
 required = True
 
 [clm]
-tag = release-clm5.0.17
+branch = newsrfdataAntwetlndsfix
 protocol = git
-repo_url = https://github.com/ESCOMP/ctsm
+repo_url = https://github.com/ekluzek/ctsm
 local_path = components/clm
 externals = Externals_CLM.cfg
 required = True
@@ -43,9 +43,9 @@ local_path = components/mosart
 required = True
 
 [pop]
-tag = pop2_cesm2_1_rel_n01
+tag = cesm_pop_2_1_20190222
 protocol = svn
-repo_url = https://svn-ccsm-models.cgd.ucar.edu/pop2/release_tags
+repo_url = https://svn-ccsm-models.cgd.ucar.edu/pop2/trunk_tags
 local_path = components/pop
 externals = Externals_POP.cfg
 required = True

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -12,7 +12,7 @@
     The notation for the compset longname is
     TIME_ATM[%phys]_LND[%phys]_ICE[%phys]_OCN[%phys]_ROF[%phys]_GLC[%phys]_WAV[%phys][_ESP%phys][_BGC%phys]
     Where for the specific compsets below the following is supported
-    TIME = Time period (e.g. 2000, HIST, RCP8...)
+    TIME = Time period (e.g. 2000, HIST, SSP585...)
     ATM  = [CAM40, CAM50, CAM60]
     LND  = [CLM45, CLM50, SLND]
     ICE  = [CICE, DICE, SICE]
@@ -163,19 +163,19 @@
     <lname>1850_CAM50_CLM45%BGC_CICE_POP2_MOSART_SGLC_SWAV</lname>
   </compset>
 
+  <!-- CMIP6 future scenarios with standard CAM (not WACCM) -->
   <compset>
-    <alias>BRCP85L45BGCR</alias>
-    <lname>RCP8_CAM60_CLM45%BGC_CICE_POP2_RTM_SGLC_SWAV</lname>
+    <alias>BSSP585</alias>
+    <lname>BSSP585_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <science_support grid="f09_g17_gl4"/>
+    <science_support grid="f09_g17"/>
   </compset>
-
+  <!-- Same as above, but with cmip6-related modifiers for some components -->
   <compset>
-    <alias>BRCP85C5L45BGC</alias>
-    <lname>RCP8_CAM50_CLM45%BGC_CICE_POP2_MOSART_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>BC5L45BGCR</alias>
-    <lname>2000_CAM50_CLM45%BGC_CICE_POP2_RTM_SGLC_SWAV</lname>
+    <alias>BSSP585cmip6</alias>
+    <lname>SSP585_CAM60_CLM50%BGC-CROP-CMIP6DECK_CICE%CMIP6_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <science_support grid="f09_g17_gl4"/>
+    <science_support grid="f09_g17"/>
   </compset>
 
   <!-- Climate Simulation Lab compsets for Keith Lindsay -->
@@ -238,8 +238,8 @@
         <value compset="2000_"     >0001-01-01</value>
         <value compset="HIST_"     >1850-01-01</value>
         <value compset="5505_"     >1955-01-01</value>
-        <value compset="RCP[2468]_">2005-01-01</value>
         <value compset="2013_"     >2013-01-01</value>
+        <value compset="SSP"       >2015-01-01</value>
         <value compset="SSP(1-2.6|5-8.5)_">2015-01-01</value>
         <value compset="SSP5-3.4_" >2040-01-01</value>
       </values>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -256,6 +256,7 @@
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="1850_CAM60%WC.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">0134-01-01</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="HIST_CAM60%WC.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">0056-01-01</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP(1-2.6|5-8.5)_CAM60%WCTS_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3">2015-01-01</value>
+        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="^SSP[0-9]_CAM60_CLM50%BGC-CROP.*CICE.*POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">2015-01-01</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP5-3.4_CAM60%WCTS_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3">2040-01-01</value>
 
       </values>
@@ -274,6 +275,7 @@
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="HIST_CAM60%WC.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">hybrid</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP(1-2.6|5-8.5)_CAM60%WCTS_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3">hybrid</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP5-3.4_CAM60%WCTS_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3">hybrid</value>
+        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="^SSP[0-9]_CAM60_CLM50%BGC-CROP.*CICE.*POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">hybrid</value>
       </values>
     </entry>
 
@@ -302,6 +304,7 @@
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="HIST_CAM60%WC.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">b.e21.BW1850.f09_g17.CMIP6-piControl.001</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP(1-2.6|5-8.5)_CAM60%WCTS_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3">b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.001</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP5-3.4_CAM60%WCTS_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3">b.e21.BWSSP585cmip6.f09_g17.CMIP6-SSP5-8.5-WACCM.001</value>
+        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="^SSP[0-9]_CAM60_CLM50%BGC-CROP.*CICE.*POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">b.e21.BHIST.f09_g17.CMIP6-historical.010</value>
       </values>
     </entry>
 
@@ -317,6 +320,7 @@
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="1850_CAM60%WC.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">cesm2_init</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="HIST_CAM60%WC.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">cesm2_init</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP.*_CAM60%WCTS_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3">cesm2_init</value>
+        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="^SSP[0-9]_CAM60_CLM50%BGC-CROP.*CICE.*POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">cesm2_init</value>
       </values>
     </entry>
 

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -176,7 +176,7 @@
   <!-- CMIP6 future scenarios with standard CAM (not WACCM) -->
   <compset>
     <alias>BSSP585</alias>
-    <lname>BSSP585_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <lname>SSP585_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
     <science_support grid="f09_g17_gl4"/>
     <science_support grid="f09_g17"/>
   </compset>
@@ -243,14 +243,14 @@
 
   <entries>
     <entry id="RUN_STARTDATE">
-      <values>
-        <value compset="1850_"     >0001-01-01</value>
-        <value compset="2000_"     >0001-01-01</value>
-        <value compset="HIST_"     >1850-01-01</value>
-        <value compset="5505_"     >1955-01-01</value>
-        <value compset="2013_"     >2013-01-01</value>
-        <value compset="SSP(126|245|370|585)_">2015-01-01</value>
-        <value compset="SSP534_"   >2040-01-01</value>
+      <values match="first">
+        <value compset="1850_"              >0001-01-01</value>
+        <value compset="2000_"              >0001-01-01</value>
+        <value compset="HIST_"              >1850-01-01</value>
+        <value compset="5505_"              >1955-01-01</value>
+        <value compset="2013_"              >2013-01-01</value>
+        <value compset="SSP534_CAM60%WCTS"  >2040-01-01</value>
+        <value compset="SSP[0-9]+_"         >2015-01-01</value>
       </values>
     </entry>
     <entry id="RUN_REFDATE">
@@ -264,9 +264,8 @@
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="_CAM60%WC.*%1PCT.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3"     >0070-01-01</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="1850_CAM60%WC.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">0134-01-01</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="HIST_CAM60%WC.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">0056-01-01</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP(126|245|370|585)_CAM60%WCTS_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3">2015-01-01</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="^SSP[0-9]_CAM60_CLM50%BGC-CROP.*CICE.*POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">2015-01-01</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP534_CAM60%WCTS_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3">2040-01-01</value>
+        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP[0-9]+_CAM60.*_CLM50%BGC-CROP.*CICE.*POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">2015-01-01</value>
 
       </values>
     </entry>
@@ -282,9 +281,7 @@
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="_CAM60%WC.*%1PCT.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3"     >hybrid</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="1850_CAM60%WC.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">hybrid</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="HIST_CAM60%WC.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">hybrid</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP(126|245|370|585)_CAM60%WCTS_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3">hybrid</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="^SSP[0-9]_CAM60_CLM50%BGC-CROP.*CICE.*POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">hybrid</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP534_CAM60%WCTS_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3">hybrid</value>
+        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP[0-9]+_CAM60.*_CLM50%BGC-CROP.*CICE.*POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">hybrid</value>
       </values>
     </entry>
 
@@ -311,9 +308,9 @@
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="_CAM60%WC.*%1PCT.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3"     >b.e21.BW1850.f09_g17.CMIP6-piControl.001</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="1850_CAM60%WC.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">b.e20.B1850.f09_g17.pi_control.all.299_merge_v2waccm</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="HIST_CAM60%WC.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">b.e21.BW1850.f09_g17.CMIP6-piControl.001</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP(126|245|370|585)_CAM60%WCTS_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3">b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.001</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP534_CAM60%WCTS_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3">b.e21.BWSSP585cmip6.f09_g17.CMIP6-SSP5-8.5-WACCM.001</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="^SSP[0-9]_CAM60_CLM50%BGC-CROP.*CICE.*POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">b.e21.BHIST.f09_g17.CMIP6-historical.010</value>
+        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP(126|245|370|585)_CAM60%WCTS_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.001</value>
+        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP534_CAM60%WCTS_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">b.e21.BWSSP585cmip6.f09_g17.CMIP6-SSP5-8.5-WACCM.001</value>
+        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP[0-9]+_CAM60.*_CLM50%BGC-CROP.*_CICE.*POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">b.e21.BHIST.f09_g17.CMIP6-historical.010</value>
       </values>
     </entry>
 
@@ -328,8 +325,7 @@
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="_CAM60%WC.*%1PCT.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3"     >cesm2_init</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="1850_CAM60%WC.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">cesm2_init</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="HIST_CAM60%WC.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">cesm2_init</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP.*_CAM60%WCTS_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3">cesm2_init</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="^SSP[0-9]_CAM60_CLM50%BGC-CROP.*CICE.*POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">cesm2_init</value>
+        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP[0-9]+_CAM60.*_CLM50%BGC-CROP.*CICE.*POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">cesm2_init</value>
       </values>
     </entry>
 
@@ -358,7 +354,7 @@
         <!-- Need because ref case is non-transient -->
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7" compset="HIST_CAM60%WC.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">use_init_interp=.true.</value>
 
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7" compset="SSP.*_CAM60%WCTS_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3">use_init_interp=.true.</value>
+        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7" compset="SSP.*_CAM60.*_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">use_init_interp=.true.</value>
       </values>
     </entry>
 

--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -89,12 +89,13 @@
       <option name="wallclock"> 00:40 </option>
     </options>
   </test>
-  <test name="IRT" grid="f09_g17" compset="BRCP85L45BGCR" testmods="allactive/defaultio">
+  <test name="IRT" grid="f09_g17_gl4" compset="BSSP585cmip6" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
+      <machine name="cheyenne" compiler="gnu" category="prebeta"/>
     </machines>
     <options>
       <option name="wallclock"> 00:30 </option>
+      <option name="comment">Testing CMIP6 future scenario SSP5-RCP8.5 with CMIP6 usermods turned on</option>
     </options>
   </test>
   <test name="IRT_Ld7" grid="f09_g17" compset="BHIST" testmods="allactive/defaultio">
@@ -318,12 +319,13 @@
       <option name="wallclock"> 02:00 </option>
     </options>
   </test>
-  <test name="ERS_Ld7" grid="f09_g17" compset="BRCP85L45BGCR" testmods="allactive/defaultio">
+  <test name="ERS_Ld7" grid="f09_g17" compset="BSSP585" testmods="allactive/defaultio">
     <machines>
       <machine name="edison" compiler="intel" category="prebeta"/>
     </machines>
     <options>
       <option name="wallclock"> 00:30 </option>
+      <option name="comment">Restart test for CMIP6 future scenario SSP5-RCP8.5</option>
     </options>
   </test>
   <test name="NCK_Ld5" grid="f19_g17" compset="BC5L45BGCR" testmods="allactive/defaultio">
@@ -453,12 +455,21 @@
       </machine>
     </machines>
   </test>
+  <test name="SMS_D_Ld1" grid="f09_g17_gl4" compset="BSSP585" testmods="allactive/defaultio">
+    <machines>
+      <machine name="cheyenne" compiler="gnu" category="prebeta"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:30 </option>
+      <option name="comment">Debug test for CMIP6 future scenario SSP5-RCP8.5</option>
+    </options>
+  </test>
   <test name="IRT_Ld5" grid="f09_g17" compset="BHISTcmip6" testmods="allactive/defaultio_min">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="prealpha">
         <options>
           <option name="wallclock">0:30</option>
-          <option name="comment">Debug test exercising B1850cmip6</option>
+          <option name="comment">exercising B1850cmip6</option>
         </options>
       </machine>
     </machines>


### PR DESCRIPTION
Add SSP5-8.5 compsets and test

Add BSSP585, BSSP585cmip6 and a couple tests for it. Remove some of the RCP compsets and tests. This branch was made relative to cesm2.1.1-rc.01.

User interface changes?: Yes
 New compsets for CMIP% SSP5-8.5 scenario

Fixes: #104 #97

 #104 -- remove CMIP5 RCP's
 #97 -- future scenario names need to change
Testing:
  system testing: SMS_D_Ld1.f09_g17_gl4.BSSP585cmip6.cheyenne_intel.allactive-defaultio PASS

