### PR TITLE
Update manage_externals to v1.1.6 for cesm2.0 alpha branch.

### DIFF
--- a/manage_externals/manic/checkout.py
+++ b/manage_externals/manic/checkout.py
@@ -280,6 +280,13 @@ of the externals description file or examine the output of
                         'used up to two times, increasing the '
                         'verbosity level each time.')
 
+    parser.add_argument('--svn-ignore-ancestry', action='store_true', default=False,
+                        help='By default, subversion will abort if a component is '
+                        'already checked out and there is no common ancestry with '
+                        'the new URL. This flag passes the "--ignore-ancestry" flag '
+                        'to the svn switch call. (This is not recommended unless '
+                        'you are sure about what you are doing.)')
+
     #
     # developer options
     #
@@ -348,7 +355,7 @@ def main(args):
                 "No component {} found in {}".format(
                     comp, args.externals))
 
-    source_tree = SourceTree(root_dir, external)
+    source_tree = SourceTree(root_dir, external, svn_ignore_ancestry=args.svn_ignore_ancestry)
     printlog('Checking status of externals: ', end='')
     tree_status = source_tree.status()
     printlog('')

--- a/manage_externals/manic/repository_factory.py
+++ b/manage_externals/manic/repository_factory.py
@@ -11,7 +11,7 @@ from .externals_description import ExternalsDescription
 from .utils import fatal_error
 
 
-def create_repository(component_name, repo_info):
+def create_repository(component_name, repo_info, svn_ignore_ancestry=False):
     """Determine what type of repository we have, i.e. git or svn, and
     create the appropriate object.
 
@@ -20,7 +20,7 @@ def create_repository(component_name, repo_info):
     if protocol == 'git':
         repo = GitRepository(component_name, repo_info)
     elif protocol == 'svn':
-        repo = SvnRepository(component_name, repo_info)
+        repo = SvnRepository(component_name, repo_info, ignore_ancestry=svn_ignore_ancestry)
     elif protocol == 'externals_only':
         repo = None
     else:

--- a/manage_externals/manic/sourcetree.py
+++ b/manage_externals/manic/sourcetree.py
@@ -24,7 +24,7 @@ class _External(object):
 
     # pylint: disable=R0902
 
-    def __init__(self, root_dir, name, ext_description):
+    def __init__(self, root_dir, name, ext_description, svn_ignore_ancestry):
         """Parse an external description file into a dictionary of externals.
 
         Input:
@@ -36,6 +36,8 @@ class _External(object):
             correspond to something in the path.
 
             ext_description : dict - source ExternalsDescription object
+
+            svn_ignore_ancestry : bool - use --ignore-externals with svn switch
 
         """
         self._name = name
@@ -62,7 +64,8 @@ class _External(object):
         if self._externals:
             self._create_externals_sourcetree()
         repo = create_repository(
-            name, ext_description[ExternalsDescription.REPO])
+            name, ext_description[ExternalsDescription.REPO],
+            svn_ignore_ancestry=svn_ignore_ancestry)
         if repo:
             self._repo = repo
 
@@ -231,7 +234,7 @@ class SourceTree(object):
     SourceTree represents a group of managed externals
     """
 
-    def __init__(self, root_dir, model):
+    def __init__(self, root_dir, model, svn_ignore_ancestry=False):
         """
         Build a SourceTree object from a model description
         """
@@ -239,7 +242,7 @@ class SourceTree(object):
         self._all_components = {}
         self._required_compnames = []
         for comp in model:
-            src = _External(self._root_dir, comp, model[comp])
+            src = _External(self._root_dir, comp, model[comp], svn_ignore_ancestry)
             self._all_components[comp] = src
             if model[comp][ExternalsDescription.REQUIRED]:
                 self._required_compnames.append(comp)


### PR DESCRIPTION
Add ability to pass --ignore-ancestry to svn switch

Add --svn-ignore-ancestry option to argparse, and then pass it
through many calls to SvnRepository constructor. If this variable
is True, run svn switch --ignore-ancestry.

User interface changes?: Yes - added optional --svn-ignore-ancestry command line argument
Note that omitting the option retains past behavior.


Fixes: #113  Update manage_externals

Testing:
  unit tests:
  system tests: 
  manual testing: Ran checkout_externals

