### PR TITLE
Add BSSP245 and BSSP370 compsets

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [cam]
-tag = cam_cesm2_1_rel_24/components/cam
+tag = cam_cesm2_1_rel_25/components/cam
 protocol = svn
 repo_url = https://svn-ccsm-models.cgd.ucar.edu/cam1/release_tags
 local_path = components/cam
@@ -28,9 +28,9 @@ externals = Externals_CISM.cfg
 required = True
 
 [clm]
-tag = release-clm5.0.20
+branch = relfatesndepmiscupdate
 protocol = git
-repo_url = https://github.com/ESCOMP/ctsm
+repo_url = https://github.com/ekluzek/ctsm
 local_path = components/clm
 externals = Externals_CLM.cfg
 required = True
@@ -43,7 +43,7 @@ local_path = components/mosart
 required = True
 
 [pop]
-tag = pop2_cesm2_1_rel_n02
+tag = pop2_cesm2_1_rel_n04
 protocol = svn
 repo_url = https://svn-ccsm-models.cgd.ucar.edu/pop2/release_tags
 local_path = components/pop

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -394,8 +394,7 @@
        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7" compset="1850_CAM60_CLM50%BGC-CROP_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3" >use_init_interp=.true.  init_interp_method='use_finidat_areas'</value>
        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7" compset="1850_CAM60%WCTS_CLM50%BGC-CROP_CICE_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3"    >use_init_interp=.true.  init_interp_method='use_finidat_areas'</value>
        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7" compset="HIST_CAM60%WCTS_CLM50%BGC-CROP_CICE_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3"    >use_init_interp=.true.  init_interp_method='use_finidat_areas'</value>
-       <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7" compset="SSP585_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3"       >use_init_interp=.true.  init_interp_method='use_finidat_areas'</value>
-       <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7" compset="SSP126_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3"       >use_init_interp=.true.  init_interp_method='use_finidat_areas'</value>
+       <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7" compset="SSP[0-9]+_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3"       >use_init_interp=.true.  init_interp_method='use_finidat_areas'</value>
        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7" compset="HIST_CAM60_CLM50%BGC-CROP_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">use_init_interp=.true.  init_interp_method='use_finidat_areas'</value>
         <!-- Need because ref case did not include CLM wetland masking fix -->
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7" compset="1850_CAM60_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3_BGC%BPRP">use_init_interp=.true.</value>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -187,6 +187,20 @@
     <science_support grid="f09_g17_gl4"/>
     <science_support grid="f09_g17"/>
   </compset>
+
+  <compset>
+    <alias>BSSP245</alias>
+    <lname>SSP245_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <science_support grid="f09_g17_gl4"/>
+    <science_support grid="f09_g17"/>
+  </compset>
+
+  <compset>
+    <alias>BSSP370</alias>
+    <lname>SSP370_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <science_support grid="f09_g17_gl4"/>
+    <science_support grid="f09_g17"/>
+  </compset>
   <!-- Same as above, but with cmip6-related modifiers for some components -->
   <compset>
     <alias>BSSP585cmip6</alias>
@@ -198,6 +212,20 @@
   <compset>
     <alias>BSSP126cmip6</alias>
     <lname>SSP126_CAM60_CLM50%BGC-CROP-CMIP6DECK_CICE%CMIP6_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <science_support grid="f09_g17_gl4"/>
+    <science_support grid="f09_g17"/>
+  </compset>
+
+  <compset>
+    <alias>BSSP245cmip6</alias>
+    <lname>SSP245_CAM60_CLM50%BGC-CROP-CMIP6DECK_CICE%CMIP6_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <science_support grid="f09_g17_gl4"/>
+    <science_support grid="f09_g17"/>
+  </compset>
+
+  <compset>
+    <alias>BSSP370cmip6</alias>
+    <lname>SSP370_CAM60_CLM50%BGC-CROP-CMIP6DECK_CICE%CMIP6_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
     <science_support grid="f09_g17_gl4"/>
     <science_support grid="f09_g17"/>
   </compset>


### PR DESCRIPTION
Add non-WACCM SSP2-RCP4.5 and SSP3-RCP7.0 compsets

Add two new CMIP6 future scenario compsets (total of four as there are ones with cmip6 use-case turned on and ones without)

User interface changes?: N (other than addition of new compsets)


Fixes: [Github issue #s] And brief description of each issue. None

Testing:
  system tests:

SMS_Ln1.f09_g17.BSSP245.cheyenne_intel.allactive-defaultio
SMS_Ln1.f09_g17.BSSP370.cheyenne_intel.allactive-SMS_Ln1.f09_g17.BSSP245cmip6.cheyenne_intel.allactive-defaultio
SMS_Ln1.f09_g17.BSSP370cmip6..cheyenne_intel.allactive-defaultio


