### PR TITLE
Fix ERS_Ld5 B compset tests with defaultio_min testmod

### DIFF
--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -354,7 +354,7 @@
       <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-  <test name="ERS_Ld5" grid="f09_g17" compset="B1850_BPRP" testmods="allactive/default">
+  <test name="ERS_Ld5" grid="f09_g17" compset="B1850_BPRP" testmods="allactive/defaultio_min">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>
@@ -362,7 +362,7 @@
       <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-  <test name="ERS_Ld5" grid="f09_g17" compset="BHIST_BPRP" testmods="allactive/default">
+  <test name="ERS_Ld5" grid="f09_g17" compset="BHIST_BPRP" testmods="allactive/defaultio_min">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>


### PR DESCRIPTION
Fix ERS_Ld5 B compset tests that were too short.

ERS_Ld5.f09_g17.B1850_BPRP.cheyenne_intel.allactive-default and ERS_Ld5.f09_g17.BHIST_BPRP.cheyenne_intel.allactive-default were failing the restart test in pop pop.h.once file because the test was configured to be too short.  This was fixed by using the defaultio_min testmod that increased the io frequency of pop.

User interface changes?: [No
[ If yes, describe what changed, and steps taken to ensure backward compatibilty ]

Fixes: [Github issue #s] And brief description of each issue.

Testing:
  unit tests:
  system tests:
  manual testing:ERS_Ld5.f09_g17.B1850_BPRP.cheyenne_intel.allactive-defaultio_min
                          ERS_Ld5.f09_g17.BHIST_BPRP.cheyenne_intel.allactive-defaultio_min

