### PR TITLE
Rename BWma1850cmip6 and BWmaHISTcmip6

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -174,13 +174,13 @@
   </compset>
 
   <compset>
-    <alias>BWma1850cmip6</alias>
-    <lname>1850_CAM60%WCCM_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3</lname>
+    <alias>BWma1850</alias>
+    <lname>1850_CAM60%WCCM_CLM50%BGC-CROP_CICE_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3</lname>
   </compset>
 
   <compset>
-    <alias>BWmaHISTcmip6</alias>
-    <lname>HIST_CAM60%WCCM_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3</lname>
+    <alias>BWmaHIST</alias>
+    <lname>HIST_CAM60%WCCM_CLM50%BGC-CROP_CICE_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3</lname>
   </compset>
 
   <compset>

--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -318,7 +318,7 @@
       <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-  <test name="SMS_Ld5" grid="f19_g17" compset="BWma1850cmip6" testmods="allactive/default">
+  <test name="SMS_Ld5" grid="f19_g17" compset="BWma1850" testmods="allactive/default">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
       <machine name="cheyenne" compiler="intel" category="bwaccm"/>
@@ -327,25 +327,7 @@
       <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-  <test name="SMS_Ld1" grid="f09_g17" compset="BWma1850cmip6" testmods="allactive/default">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="bwaccm"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 01:00 </option>
-    </options>
-  </test>
-  <test name="SMS_Ld5" grid="f19_g17" compset="BWmaHISTcmip6" testmods="allactive/default">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="bwaccm"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 01:00 </option>
-    </options>
-  </test>
-  <test name="SMS_Ld1" grid="f09_g17" compset="BWmaHISTcmip6" testmods="allactive/default">
+  <test name="SMS_Ld5" grid="f19_g17" compset="BWmaHIST" testmods="allactive/default">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
       <machine name="cheyenne" compiler="intel" category="bwaccm"/>
@@ -458,14 +440,6 @@
     <options>
       <option name="wallclock"> 00:30 </option>
       <option name="comment">Restart test for CMIP6 future scenario SSP5-RCP8.5</option>
-    </options>
-  </test>
-  <test name="NCK_Ld5" grid="f19_g17" compset="BC5L45BGCR" testmods="allactive/defaultio">
-    <machines>
-      <machine name="cheyenne" compiler="gnu" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="NCK_Ld5" grid="f19_g17" compset="B1850G" testmods="allactive/cism/test_coupling">


### PR DESCRIPTION
Rename BWma1850cmip6 and BWmaHISTcmip6 to BWma1850 and BWmaHIST.
Remove f0.9 BWma1850/BWmaHIST tests.  Remove BC5L45BGCR test.



User interface changes?: No


Fixes: [Github issue #s] 

Testing:
  unit tests:
  system tests:
  manual testing:

