### PR TITLE
Remove failing BWSSP534os tests

### DIFF
--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -167,14 +167,6 @@
       <option name="wallclock"> 00:30 </option>
     </options>
   </test>
-  <test name="ERS_Ld3" grid="f09_g17" compset="BWSSP534oscmip6" testmods="allactive/defaultio_min">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="bwaccm"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
   <test name="SMS_D_Ln9" grid="f09_g17" compset="BWSSP126cmip6" testmods="allactive/defaultio_min">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
@@ -203,14 +195,6 @@
     </options>
   </test>
   <test name="SMS_D_Ln9" grid="f09_g17" compset="BWSSP585cmip6" testmods="allactive/defaultio_min">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="bwaccm"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="SMS_D_Ln9" grid="f09_g17" compset="BWSSP534oscmip6" testmods="allactive/defaultio_min">
     <machines>
       <machine name="cheyenne" compiler="intel" category="bwaccm"/>
     </machines>
@@ -248,14 +232,6 @@
   <test name="SMS_D_Ln9" grid="f09_g17" compset="BWSSP585" testmods="allactive/defaultio_min">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="cheyenne" compiler="intel" category="bwaccm"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="SMS_D_Ln9" grid="f09_g17" compset="BWSSP534os" testmods="allactive/defaultio_min">
-    <machines>
       <machine name="cheyenne" compiler="intel" category="bwaccm"/>
     </machines>
     <options>

--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -212,7 +212,6 @@
   </test>
   <test name="SMS_D_Ln9" grid="f09_g17" compset="BWSSP534oscmip6" testmods="allactive/defaultio_min">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
       <machine name="cheyenne" compiler="intel" category="bwaccm"/>
     </machines>
     <options>
@@ -257,7 +256,6 @@
   </test>
   <test name="SMS_D_Ln9" grid="f09_g17" compset="BWSSP534os" testmods="allactive/defaultio_min">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
       <machine name="cheyenne" compiler="intel" category="bwaccm"/>
     </machines>
     <options>


### PR DESCRIPTION
Remove BWSSP534os and BWSSP534oscmip6 tests that aren't support and
are failing the tests.
