### PR TITLE
Add MOM6 and FMS as Optional Externals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # managed directories that are checked out by the externals tool
 cime/
 components/
+libraries/
 
 # generated local files
 *.log

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -65,6 +65,22 @@ repo_url = https://svn-ccsm-models.cgd.ucar.edu/ww3/trunk_tags
 local_path = components/ww3
 required = True
 
+[mom]
+tag = mi_20190821
+protocol = git
+repo_url = https://github.com/ESCOMP/MOM_interface
+local_path = components/mom
+externals = Externals.cfg
+required = False
+
+[fms]
+tag = fi_20190820
+protocol = git
+repo_url = https://github.com/ESCOMP/FMS_interface
+local_path = libraries/FMS
+externals = Externals_FMS.cfg
+required = True
+
 [externals_description]
 schema_version = 1.0.0
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -79,7 +79,7 @@ protocol = git
 repo_url = https://github.com/ESCOMP/FMS_interface
 local_path = libraries/FMS
 externals = Externals_FMS.cfg
-required = True
+required = False
 
 [externals_description]
 schema_version = 1.0.0


### PR DESCRIPTION
Adds MOM6 as an optional component and FMS as an optional library in CESM.

User interface changes?: No/Yes

Fixes: n/a
Testing:
  aux_mom
