### PR TITLE
Add describe_version script

### DIFF
--- a/describe_version
+++ b/describe_version
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+"""Describes the CESM version and any local modifications"""
+
+from __future__ import print_function
+
+import os
+import argparse
+import subprocess
+
+def commandline_args():
+    """Parse and return command-line arguments
+    """
+
+    # We don't really need an argument parser, since there currently aren't any
+    # arguments. But providing this allows supporting a '--help' option with a
+    # description.
+
+    description = """
+Script for describing the CESM version and any local modifications
+
+Simply run:
+
+    ./describe_version
+
+without any arguments.
+
+You may want to redirect the output to a file, such as:
+
+    ./describe_version > current_version.txt
+"""
+
+    parser = argparse.ArgumentParser(
+        description=description,
+        formatter_class=argparse.RawTextHelpFormatter)
+
+    args = parser.parse_args()
+    return args
+
+def main():
+    """Main function for describe_version"""
+    # We currently don't actually need any arguments, but call this to allow '--help' usage
+    _ = commandline_args()
+
+    # Allow this script to run correctly even if invoked from some other directory; note that
+    # we assume that the script resides in the top level of the CESM checkout.
+    cesmroot = os.path.dirname(os.path.realpath(__file__))
+
+    separator = 72*'-' + '\n'
+
+    # The '--long' option to git describe forces it to always show the hash, even if we're
+    # on a tag.
+    git_describe = subprocess.check_output(['git', 'describe', '--long'],
+                                           cwd=cesmroot,
+                                           universal_newlines=True)
+    print(separator + 'git describe:\n' + git_describe + separator)
+
+    git_status = subprocess.check_output(['git', 'status'],
+                                         cwd=cesmroot,
+                                         universal_newlines=True)
+    print(separator + 'git status:\n' + git_status + separator)
+
+    manic = os.path.join('manage_externals', 'checkout_externals')
+    # Give '--verbose' twice to give very verbose output, showing all modified files in
+    # each external.
+    manage_externals_status = subprocess.check_output([manic, '--status', '--verbose', '--verbose'],
+                                                      cwd=cesmroot,
+                                                      universal_newlines=True)
+    print(separator + 'manage_externals status:\n' + manage_externals_status + separator)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This describes the CESM version and any local modifications.

This is mainly to help users describe their CESM version for the sake of
forum posts.

User interface changes?: No

Fixes: ESCOMP/cesm#132 (Add a script that prints version information)

Testing:
  unit tests: none
  system tests: none
  manual testing: Ran script with and without local modifications, invoked from current directory and from elsewhere. Also ran pylint on the new code.

Here is sample output. I am happy to tweak the output format if others prefer something different. I have deliberately made the output pretty verbose to help avoid initial back-and-forths with people posting to the forums: I wanted to be able to see any files they have changed in their sandbox. However, note that it's also possible to just get a quick view of the externals that have been modified by scanning the first two columns of output in the manage_externals section (looking for 's' and 'M' in these first two columns).

```
------------------------------------------------------------------------
git describe:
cesm2.1.2-rc.03-0-g6218524
------------------------------------------------------------------------

------------------------------------------------------------------------
git status:
On branch describe_version
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

	new file:   describe_version

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   describe_version

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	current_version.txt

------------------------------------------------------------------------

------------------------------------------------------------------------
manage_externals status:
Processing externals description file : Externals.cfg
Processing externals description file : Externals_CLM.cfg
Processing externals description file : Externals_POP.cfg
Processing externals description file : Externals_CISM.cfg
Processing externals description file : Externals_CAM.cfg
Checking status of externals: clm, fates, ptclm, mosart, ww3, cime, cice, pop, cvmix, marbl, cism, source_cism, rtm, cam, clubb, carma, cosp2, chem_proc,
 M  ./cime
        modified sandbox, on cime5.6.28
            HEAD detached at cime5.6.28
            Changes not staged for commit:
              (use "git add <file>..." to update what will be committed)
              (use "git checkout -- <file>..." to discard changes in working directory)

            	modified:   README.md

            Untracked files:
              (use "git add <file>..." to include in what will be committed)

            	scripts/create_newcase.log
            	src/drivers/nuopc/

            no changes added to commit (use "git add" and/or "git commit -a")

    ./components/cam
        clean sandbox, on cam_cesm2_1_rel_38
            HEAD detached at cam_cesm2_1_rel_38
            nothing to commit, working tree clean

    ./components/cam/chem_proc
        clean sandbox, on tools/proc_atm/chem_proc/release_tags/chem_proc5_0_03_rel

    ./components/cam/src/physics/carma/base
        clean sandbox, on carma/release_tags/carma3_49_rel

    ./components/cam/src/physics/clubb
        clean sandbox, on vendor_clubb_r8099_n03
            HEAD detached at vendor_clubb_r8099_n03
            nothing to commit, working tree clean

    ./components/cam/src/physics/cosp2/src
        clean sandbox, on CFMIP/COSPv2.0/tags/v2.1.4cesm/src

    ./components/cice
        clean sandbox, on cice5_cesm2_1_1_20190321
            HEAD detached at cice5_cesm2_1_1_20190321
            nothing to commit, working tree clean

    ./components/cism
        clean sandbox, on release-cesm2.0.04
            HEAD detached at release-cesm2.0.04
            nothing to commit, working tree clean

    ./components/cism/source_cism
        clean sandbox, on release-cism2.1.03
            HEAD detached at release-cism2.1.03
            nothing to commit, working tree clean

    ./components/clm
        clean sandbox, on release-clm5.0.29
            HEAD detached at release-clm5.0.29
            nothing to commit, working tree clean

    ./components/clm/src/fates
        clean sandbox, on fates_s1.21.0_a7.0.0_br_rev2
            HEAD detached at fates_s1.21.0_a7.0.0_br_rev2
            nothing to commit, working tree clean

    ./components/clm/tools/PTCLM
        clean sandbox, on PTCLM2_180611
            HEAD detached at PTCLM2_180611
            nothing to commit, working tree clean

    ./components/mosart
        clean sandbox, on release-cesm2.0.03
            HEAD detached at release-cesm2.0.03
            nothing to commit, working tree clean

    ./components/pop
        clean sandbox, on pop2_cesm2_1_rel_n06
            HEAD detached at pop2_cesm2_1_rel_n06
            Untracked files:
              (use "git add <file>..." to include in what will be committed)

            	externals/CVMix/
            	externals/MARBL/

            nothing added to commit but untracked files present (use "git add" to track)

    ./components/pop/externals/CVMix
        clean sandbox, on v0.93-beta
            HEAD detached at v0.93-beta
            nothing to commit, working tree clean

    ./components/pop/externals/MARBL
        clean sandbox, on cesm2.1-n00
            HEAD detached at cesm2.1-n00
            nothing to commit, working tree clean

    ./components/rtm
        clean sandbox, on release-cesm2.0.03
            HEAD detached at release-cesm2.0.03
            nothing to commit, working tree clean

    ./components/ww3
        clean sandbox, on ww3_181001
            HEAD detached at ww3_cesm2_1_rel_01
            nothing to commit, working tree clean

------------------------------------------------------------------------
```
