### PR TITLE
Update CESM2 copyright notice

### DIFF
--- a/Copyright
+++ b/Copyright
@@ -1,60 +1,75 @@
-CESM1.5: Copyright Notice and Disclaimer
+CESM2 Copyright and Terms of Use
 
-The Community Earth System Model (CESM was developed in cooperation with 
-the National Science Foundation, the Department of Energy, 
-the National Aeronautics and Space Administration, and 
-the University Corporation for Atmospheric Research National Center for Atmospheric Research.
+Copyright (c) 2018, University Corporation for Atmospheric Research
+(UCAR) All rights reserved.
 
-Except for the segregable components listed below, CESM is public domain software. 
-There may be other third party tools and libraries that are embedded, and 
-they may have their own copyright notices and terms.
+The Community Earth System Model (CESM) was developed primarily in
+cooperation with the National Science Foundation, the Department of
+Energy, the National Aeronautics and Space Administration, and the
+University Corporation for Atmospheric Research National Center for
+Atmospheric Research.
 
-The following components are copyrighted and may only be used, modified, 
+THIS SOFTWARE IS PROVIDED BY UCAR AND ANY CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UCAR OR ANY CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+The following components are copyrighted and may only be used, modified,
 or redistributed under the terms indicated below.
 
 Code		 Institution		Copyright	Terms of Use/Disclaimer
 ----		 -----------	 	---------	-----------------------
-ESMF		 University of 		Copyright 	University of Illinois/NCSA Open Source License
-		 Illinois/NCSA 		2002-2009, 
-					University of 
-					Illinois/NCSA 
-					Open Source 
-					License
-		 	
-POP,SCRIP,CICE	Los Alamos National	Copyright 2008	Los Alamos National Security, LLC 
-		Laboratory   		Los Alamos 
-					National 
-					Security, LLC
-		
-CISM            NCAR/LANL/ORNL/SNL/     Copyright       GNU Lesser General Public License v. 3
-                LBNL/NYU/U. Bristol/    2004-2018,      CISM is free software: you can redistribute it
-                U. Edinburgh/           GNU Lesser      and/or modify it under the terms of the GNU
-                U. Montana/U. Swansea   General Public  Lesser General Public License as published by the
-                                        License v. 3    Free Software Foundation, either version 3 of the
-                                                        License, or (at your option) any later version.
-		 
 AER RRTMG	Atmospheric		Copyright	AER RRTMG Copyright
     		and			2002-2010, 
 		Environmental 		Atmospheric 
 		Research, Inc.		and 
 					Environmental 
 					Research, Inc.
-		
-MCT		Argonne			Copyright 2000,	MCT Copyright
-		National		2010, 
-		Laboratory		University of 
-					Chicago.
+
+Common          University Corporation  Copyright 2017,   CIME License
+Infrastructure  for Atmospheric         University
+for Modeling    Research (UCAR) and DOE Corporation for
+the Earth       BER E3SM project team   Atmospheric
+(CIME)          members, including      Research (UCAR);
+                those at SNL and ANL    Copyright 2017,
+                                        Sandia
+                                        Corporation;
+                                        Copyright 2017,
+                                        UChicago Argonne,
+                                        LLC
+
+ESMF		 University of 		Copyright 	University of Illinois/NCSA Open Source License
+		 Illinois/NCSA 		2002-2009, 
+					University of 
+					Illinois/NCSA 
+					Open Source 
+					License
+
+Functionally    UCAR/NCAR, UC Berkeley  Copyright 2017,  FATES License
+Assembled       and DOE                 University
+Terrestrial                             Corporation for
+Ecosystem                               Atmospheric
+Simulator                               Research (UCAR),
+(FATES)                                 the U.S.
+                                        Department of
+                                        Energy, and the
+                                        University of
+                                        California
+
+CISM Community  NCAR/LANL/ORNL/SNL/     Copyright       GNU Lesser General Public License v. 3
+Ice Sheet       LBNL/NYU/U. Bristol/    2004-2018,      CISM is free software: you can redistribute it
+Model           U. Edinburgh/           GNU Lesser      and/or modify it under the terms of the GNU
+                U. Montana/U. Swansea   General Public  Lesser General Public License as published by the
+                                        License v. 3    Free Software Foundation, either version 3 of the
+                                                        License, or (at your option) any later version.
 		 
-ICSSP		 N/A			Copyright 2003, ISCCP Simulator Software
-		 			2010, Steve 
-					Klein and Mark 
-					Webb
-					
-XML/Lite	Wadsack-Allen		Copyright 2001, The documentation for the Perl XML-Lite 
-		Digital Group		2010 	  	module is no longer available on-line. 
-					Wadsack-Allen 
-					Digital Group
-		
 Inf_NaN		Lahey			Copyright(c)	Copies of this source code, or standalone compiled 
 _Detection 	Computer		2003, Lahey	files derived from this source may not be sold 
 module		Systems, Inc.		Computer	without permission from Lahey Computers Systems. 
@@ -64,12 +79,40 @@ module		Systems, Inc.		Computer	without permission from Lahey Computers Systems.
 							permitted, provided this copyright notice and header 
 							are included.
 					 
+International	 N/A			Copyright 2003, ISCCP Simulator Software
+Satellite	 			2010, Steve 
+Cloud					Klein and Mark 
+Climatology				Webb
+Project
+(ISCCP)
 
-THIS SOFTWARE IS PROVIDED BY UCAR AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL UCAR OR ANY CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
-IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+MCT		Argonne			Copyright 2011,	MCT Copyright
+		National		University of
+		Laboratory		Chicago 
+		 
+Parallel Ocean  Los Alamos National     Copyright 2015, Los Alamos National Security, LLC
+Program (POP2)  Laboratory              Los Alamos
+                                        National
+                                        Security, LLC
 
+The Los Alamos  Los Alamos National     Copyright 2017, Los Alamos National Security, LLC
+Sea Ice Model   Laboratory              Los Alamos
+(CICE)                                  National
+                                        Security, LLC
+
+Spherical       Los Alamos National     Copyright 2015, Los Alamos National Security, LLC
+Coordinate      Laboratory              Los Alamos
+Remapping and                           National
+Interpolation                           Security, LLC
+Package (SCRIP)
+
+XML/Lite	Wadsack-Allen		Copyright 2001, The documentation for the Perl XML-Lite 
+		Digital Group		2010 	  	module is no longer available on-line. 
+					Wadsack-Allen 
+					Digital Group
+		
+For more details on the copyrights of the above components, see
+http://www.cesm.ucar.edu/models/cesm2/copyright.html
+
+There may be other third party tools and libraries that are integrated
+into CESM, and they may have their own copyright notices and terms.


### PR DESCRIPTION
Update to match http://www.cesm.ucar.edu/models/cesm2/copyright.html,
which is the copyright notice approved by UCAR legal.

In particular, note the removal of the term "public domain software",
because that is incorrect legal terminology.

User interface changes?: No

Testing: none
  unit tests:
  system tests:
  manual testing:

