### PR TITLE
Fix BWma1850 compset

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -49,7 +49,7 @@
   </compset>
   <compset>
     <alias>BWma1850</alias>
-    <lname>1850_CAM60%WCCM_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_WW3</lname>
+    <lname>1850_CAM60%WCCM_CLM50%BGC-CROP_CICE_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3</lname>
   </compset>
 
   <compset>


### PR DESCRIPTION
Needed to add %NDEP to POP to get BWma1850 compsets working.



User interface changes?: NO


Fixes: [Github issue #s] And brief description of each issue.

Testing:
  unit tests:
  system tests:
  manual testing: SMS_Ld5.f09_g17.BWma1850.cheyenne_intel.allactive-defaultio,
                           SMS_Ld5.f19_g17.BWma1850.cheyenne_intel.allactive-defaultio

