### PR TITLE
Update issue & PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,0 @@
-### Summary of Issue:
-### Expected behavior and actual behavior:
-### Steps to reproduce the problem. Include externals description file(s) and link to public repository):
-### What is the changeset ID of the code, and the machine you are using:
-### have you modified the code? If so, it must be committed and available for testing:
-### Screen output or log file showing the error message and context:

--- a/.github/ISSUE_TEMPLATE/01_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report, CESM-wide or unknown component
+about: Report a problem with CESM for an unknown component; in many cases, one of the links below is more appropriate
+
+---
+
+### Brief summary of bug
+
+[Give a one or two sentence summary. This could be the same as the issue title if you feel that is a sufficient summary.]
+
+### General bug information
+
+**CESM version you are using:** [Output of `git describe`]
+
+**Machine you are using:** [Fill this in]
+
+**Have you modified the code? (If so, please point us to you changes.):** [Yes / No]
+
+### Details of bug
+
+[Fill in details here.]
+
+### Steps to reproduce the problem. Include externals description file(s) and link to public repository
+
+[Fill this in with anything relevant that you haven't already noted; if there is nothing to add, delete this section.]
+
+### Screen output or log file showing the error message and context
+
+[Fill this in with anything relevant that you haven't already noted; if there is nothing to add, delete this section.]

--- a/.github/ISSUE_TEMPLATE/02_enhancement.md
+++ b/.github/ISSUE_TEMPLATE/02_enhancement.md
@@ -1,0 +1,7 @@
+---
+name: Enhancement request, CESM-wide or unknown component
+about: Suggest a CESM-wide enhancement; in many cases, one of the links below is more appropriate
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: CESM forums
     url: https://bb.cgd.ucar.edu/cesm/
     about: For support with model use, troubleshooting, etc., please use the CESM forums
+  - name: CAM issue
+    url: https://github.com/ESCOMP/CAM/issues
+    about: Issue with CAM (Community Atmosphere Model)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: CESM forums
+    url: https://bb.cgd.ucar.edu/cesm/
+    about: For support with model use, troubleshooting, etc., please use the CESM forums

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,8 +7,8 @@ contact_links:
     url: https://github.com/ESMCI/cime/issues/new/choose
     about: Issue with CIME (scripting infrastructure, share code, etc.)
   - name: CAM issue
-    url: https://github.com/ESCOMP/CAM/issues/new/choose
-    about: Issue with CAM (Community Atmosphere Model)
+    url: https://bb.cgd.ucar.edu/cesm/forums/cam.133/
+    about: Issue with CAM (Community Atmosphere Model) - please report via forums
   - name: CTSM / CLM issue
     url: https://github.com/ESCOMP/CTSM/issues/new/choose
     about: Issue with CTSM / CLM (Community Terrestrial Systems Model / Community Land Model)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://bb.cgd.ucar.edu/cesm/
     about: For support with model use, troubleshooting, etc., please use the CESM forums
   - name: CAM issue
-    url: https://github.com/ESCOMP/CAM/issues
+    url: https://github.com/ESCOMP/CAM/issues/new/choose
     about: Issue with CAM (Community Atmosphere Model)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,9 +3,39 @@ contact_links:
   - name: CESM forums
     url: https://bb.cgd.ucar.edu/cesm/
     about: For support with model use, troubleshooting, etc., please use the CESM forums
+  - name: CIME issue
+    url: https://github.com/ESMCI/cime/issues/new/choose
+    about: Issue with CIME (scripting infrastructure, share code, etc.)
   - name: CAM issue
     url: https://github.com/ESCOMP/CAM/issues/new/choose
     about: Issue with CAM (Community Atmosphere Model)
   - name: CTSM / CLM issue
     url: https://github.com/ESCOMP/CTSM/issues/new/choose
     about: Issue with CTSM / CLM (Community Terrestrial Systems Model / Community Land Model)
+  - name: POP issue
+    url: https://github.com/ESCOMP/POP2-CESM/issues/new/choose
+    about: Issue with POP in CESM (Parallel Ocean Program)
+  - name: MOM issue
+    url: https://github.com/ESCOMP/MOM_interface/issues/new/choose
+    about: Issue with MOM in CESM (Modular Ocean Model)
+  - name: CICE5 issue
+    url: https://github.com/ESCOMP/CESM_CICE5/issues/new/choose
+    about: Issue with CICE5
+  - name: CISM issue
+    url: https://github.com/ESCOMP/cism-wrapper/issues/new/choose
+    about: Issue with CISM (Community Ice Sheet Model)
+  - name: MOSART issue
+    url: https://github.com/ESCOMP/MOSART/issues/new/choose
+    about: Issue with MOSART in CESM (Model for Scale Adaptive River Transport)
+  - name: RTM issue
+    url: https://github.com/ESCOMP/RTM/issues/new/choose
+    about: Issue with RTM (River Transport Model)
+  - name: WW3 issue
+    url: https://github.com/ESCOMP/WW3-CESM/issues/new/choose
+    about: Issue with WW3 in CESM (WaveWatch III)
+  - name: CMEPS issue
+    url: https://github.com/ESCOMP/CMEPS/issues/new/choose
+    about: Issue with CMEPS (NUOPC Community Mediator for Earth Prediction Systems )
+  - name: FMS issue
+    url: https://github.com/ESCOMP/FMS_interface/issues/new/choose
+    about: Issue with FMS in CESM

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: CAM issue
     url: https://github.com/ESCOMP/CAM/issues/new/choose
     about: Issue with CAM (Community Atmosphere Model)
+  - name: CTSM / CLM issue
+    url: https://github.com/ESCOMP/CTSM/issues/new/choose
+    about: Issue with CTSM / CLM (Community Terrestrial Systems Model / Community Land Model)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: true
 contact_links:
   - name: CESM forums
     url: https://bb.cgd.ucar.edu/cesm/
-    about: **For support with model use, troubleshooting, etc., please use the CESM forums**
+    about: For support with model use, troubleshooting, etc., please use the CESM forums
   - name: CIME issue
     url: https://github.com/ESMCI/cime/issues/new/choose
     about: Issue with CIME (scripting infrastructure, share code, etc.)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: true
 contact_links:
   - name: CESM forums
     url: https://bb.cgd.ucar.edu/cesm/
-    about: For support with model use, troubleshooting, etc., please use the CESM forums
+    about: **For support with model use, troubleshooting, etc., please use the CESM forums**
   - name: CIME issue
     url: https://github.com/ESMCI/cime/issues/new/choose
     about: Issue with CIME (scripting infrastructure, share code, etc.)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,13 @@
-[ 50 character, one line summary ]
+### Description of changes
 
-[ Description of the changes in this commit. It should be enough
-  information for someone not following this development to understand. 
-  Lines should be wrapped at about 72 characters. ]
+### Specific notes
 
-User interface changes?: [ No/Yes ]
-[ If yes, describe what changed, and steps taken to ensure backward compatibilty ]
+Contributors other than yourself, if any:
 
 Fixes: [Github issue #s] And brief description of each issue.
 
-Testing:
-  unit tests:
-  system tests:
-  manual testing:
+User interface changes?: [ No/Yes ]
+[ If yes, describe what changed, and steps taken to ensure backward compatibility ]
+
+Testing performed (automated tests and/or manual tests):
 


### PR DESCRIPTION
Updates the issue and PR templates. A major change is adding a bunch of links to other places where people should consider going for help or opening issues.

To see how this looks, go here: <https://github.com/billsacks/cesm/issues/new/choose>. My original plan was to just add a link to the CESM forums, but then I thought it could be useful to add links to open issues for any of the CESM externals. I'm not sure, though: Is this helpful or too much?

