### PR TITLE
Add mizuRoute as an external

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -60,6 +60,13 @@ repo_url = https://github.com/mvertens/mosart.git
 local_path = components/mosart
 required = True
 
+[mizuRoute]
+local_path = components/mizuRoute
+protocol = git
+repo_url = https://github.com/nmizukami/mizuRoute
+branch = ctsm-coupling
+required = True
+
 [pop]
 tag = a8fa1d
 protocol = git

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [cam]
-tag = 4df8267
+tag = 0aace94
 protocol = git
 repo_url = https://github.com/mvertens/CAM.git
 local_path = components/cam
@@ -13,8 +13,15 @@ repo_url = https://github.com/ESCOMP/CESM_CICE5
 local_path = components/cice
 required = True
 
+[mizuRoute]
+local_path = components/mizuRoute
+protocol = git
+repo_url = https://github.com/nmizukami/mizuRoute
+branch = ctsm-coupling
+required = True
+
 [cime]
-tag = 64e9f9202
+hash = 4427dd05147c42f19f5283793676867572138ed7
 protocol = git
 repo_url = https://github.com/ESMCI/cime
 local_path = cime
@@ -30,9 +37,9 @@ externals = Externals_CISM.cfg
 required = True
 
 [clm]
-tag = f5de7e42
+branch = add_mizuRoute
 protocol = git
-repo_url = https://github.com/mvertens/ctsm.git
+repo_url = https://github.com/ekluzek/ctsm.git
 local_path = components/clm
 externals = Externals_CLM.cfg
 required = True
@@ -54,17 +61,10 @@ externals = Externals.cfg
 required = True
 
 [mosart]
-tag = 2b30936
+branch = upnupopc
 protocol = git
-repo_url = https://github.com/mvertens/mosart.git
+repo_url = https://github.com/ekluzek/MOSART.git
 local_path = components/mosart
-required = True
-
-[mizuRoute]
-local_path = components/mizuRoute
-protocol = git
-repo_url = https://github.com/nmizukami/mizuRoute
-branch = ctsm-coupling
 required = True
 
 [pop]
@@ -76,9 +76,9 @@ externals = Externals_POP.cfg
 required = True
 
 [rtm]
-tag = 03a804eaa
+branch = upnuopc
 protocol = git
-repo_url = https://github.com/mvertens/rtm.git
+repo_url = https://github.com/ekluzek/rtm.git
 local_path = components/rtm
 required = True
 

--- a/Externals_cime.cfg
+++ b/Externals_cime.cfg
@@ -1,8 +1,22 @@
 [cmeps]
-hash =  de438de
+hash = 70b5daa
 protocol = git
 repo_url = https://github.com/ESCOMP/CMEPS.git
 local_path = src/drivers/nuopc/
+required = True
+
+[fox]
+hash = 0ed59c1
+protocol = git
+repo_url = https://github.com/ESMCI/fox.git
+local_path = src/externals/fox
+required = True
+
+[cdeps]
+hash = 5b29c3e
+protocol = git
+repo_url = https://github.com/ESCOMP/CDEPS.git
+local_path = src/components/cdeps
 required = True
 
 [externals_description]


### PR DESCRIPTION
### Description of changes

Add mizuRoute as an external. This will also need an update to CTSM. This is just for the nuopc_dev branch right now.

### Specific notes

There are also branch changes in CTSM that are needed for it to work.

Contributors other than yourself, if any: Naoki Mizukami

User interface changes?: No


Testing performed (automated tests and/or manual tests): 
 SMS_D_P5x1_Vnuopc_Ld5.5x5_amazon_r05.I2000Clm50SpMizGs.cheyenne_intel.mizuroute-default
 SMS_D_P36x1_Vnuopc_Ld10.f19_g17_r05.I2000Clm50SpMizGs.cheyenne_intel.mizuroute-default

