### PR TITLE
update cmeps and cdeps and make them optional

### DIFF
--- a/Externals_cime.cfg
+++ b/Externals_cime.cfg
@@ -1,16 +1,16 @@
 [cmeps]
-hash = 471ac52
+hash = 7654038
 protocol = git
 repo_url = https://github.com/ESCOMP/CMEPS.git
 local_path = src/drivers/nuopc/
-required = True
+required = False
 
-[fox]
-hash = 0ed59c1
+[cdeps]
+hash = cfc534
 protocol = git
-repo_url = https://github.com/ESMCI/fox.git
-local_path = src/externals/fox
-required = True
+repo_url = https://github.com/ESCOMP/CDEPS.git
+local_path = src/components/cdeps
+required = False
 
 [externals_description]
 schema_version = 1.0.0


### PR DESCRIPTION
### Description of changes
Updates the CMEPS and CDEPS hashes and makes these components optional since they are not needed with the mct driver. 
### Specific notes

Contributors other than yourself, if any:

Fixes: [Github issue #s] And brief description of each issue.

User interface changes?: [ No/Yes ]
[ If yes, describe what changed, and steps taken to ensure backward compatibility ]

Testing performed (automated tests and/or manual tests):

