### PR TITLE
Add B1850MOM compset, add a pelayout for cheyenne, make MOM, RTM and FMS optional components

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -43,7 +43,7 @@ protocol = git
 repo_url = https://github.com/ESCOMP/FMS_interface
 local_path = libraries/FMS
 externals = Externals_FMS.cfg
-required = True
+required = False
 
 [mom]
 tag = mi_20200724
@@ -51,7 +51,7 @@ protocol = git
 repo_url = https://github.com/ESCOMP/MOM_interface
 local_path = components/mom
 externals = Externals.cfg
-required = True
+required = False
 
 [mosart]
 tag = mosart1_0_36
@@ -73,7 +73,7 @@ tag = rtm1_0_71
 protocol = git
 repo_url = https://github.com/ESCOMP/rtm
 local_path = components/rtm
-required = True
+required = False
 
 [ww3]
 tag = ww3_200710

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -73,7 +73,7 @@ tag = rtm1_0_71
 protocol = git
 repo_url = https://github.com/ESCOMP/rtm
 local_path = components/rtm
-required = False
+required = True
 
 [ww3]
 tag = ww3_200710

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -142,6 +142,8 @@
 
   <!-- fully coupled MOM6 runs -->
   <compset>
+    <!-- MOM is an optional component of CESM and is not checked out by default
+	 use checkout_externals mom to add it -->
     <alias>B1850MOM</alias>
     <lname>1850_CAM60_CLM50%BGC-CROP_CICE_MOM6_MOSART_CISM2%NOEVOLVE_SWAV_BGC%BDRD</lname>
   </compset>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -140,6 +140,12 @@
     <lname>1850_CAM60_CLM45%SP_CICE_DOCN%SOM_MOSART_SGLC_SWAV_TEST</lname>
   </compset>
 
+  <!-- fully coupled MOM6 runs -->
+  <compset>
+    <alias>B1850MOM</alias>
+    <lname>1850_CAM60_CLM50%BGC-CROP_CICE_MOM6_MOSART_CISM2%NOEVOLVE_SWAV_BGC%BDRD</lname>
+  </compset>
+
   <!-- All active except data atmosphere
        Used for spinup and testing of CISM couplings -->
 
@@ -151,12 +157,12 @@
   <entries>
     <entry id="RUN_STARTDATE">
       <values>
-        <value compset="1850_"     >0001-01-01</value>
-        <value compset="2000_"     >0001-01-01</value>
-        <value compset="HIST_"     >1850-01-01</value>
-        <value compset="5505_"     >1955-01-01</value>
-        <value compset="RCP[2468]_">2005-01-01</value>
-        <value compset="2013_"     >2013-01-01</value>
+	<value compset="1850_"     >0001-01-01</value>
+	<value compset="2000_"     >0001-01-01</value>
+	<value compset="HIST_"     >1850-01-01</value>
+	<value compset="5505_"     >1955-01-01</value>
+	<value compset="RCP[2468]_">2005-01-01</value>
+	<value compset="2013_"     >2013-01-01</value>
       </values>
     </entry>
   </entries>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -1051,6 +1051,7 @@
   <grid name="a%0.9x1.25_l%0.9x1.25_oi%tx0.66v1_r%r05_g%gland4_w%null_z%null_m%tx0.66v1">
     <mach name="cheyenne">
       <pes pesize="any" compset="any">
+	<!-- B1850MOM gets about 7.9 ypd -->
 	<comment>none</comment>
 	<ntasks>
 	  <ntasks_atm>576</ntasks_atm>
@@ -1078,6 +1079,40 @@
 	  <rootpe_rof>0</rootpe_rof>
 	  <rootpe_ice>288</rootpe_ice>
 	  <rootpe_ocn>576</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+      <pes pesize="L" compset="any">
+	<!-- B1850MOM gets about 18 ypd -->
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>1800</ntasks_atm>
+	  <ntasks_lnd>900</ntasks_lnd>
+	  <ntasks_rof>900</ntasks_rof>
+	  <ntasks_ice>900</ntasks_ice>
+	  <ntasks_ocn>720</ntasks_ocn>
+	  <ntasks_glc>36</ntasks_glc>
+	  <ntasks_wav>36</ntasks_wav>
+	  <ntasks_cpl>1800</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>900</rootpe_ice>
+	  <rootpe_ocn>1800</rootpe_ocn>
 	  <rootpe_glc>0</rootpe_glc>
 	  <rootpe_wav>0</rootpe_wav>
 	  <rootpe_cpl>0</rootpe_cpl>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -135,69 +135,69 @@
     <mach name="cheyenne">
       <pes pesize="any" compset="CAM.+CLM.+CICE.+POP.+">
 	<comment>about 12ypd expected</comment>
-        <ntasks>
-          <ntasks_atm>288</ntasks_atm>
-          <ntasks_lnd>144</ntasks_lnd>
-          <ntasks_rof>40</ntasks_rof>
-          <ntasks_ice>108</ntasks_ice>
-          <ntasks_ocn>288</ntasks_ocn>
-          <ntasks_glc>36</ntasks_glc>
-          <ntasks_wav>36</ntasks_wav>
-          <ntasks_cpl>288</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>144</rootpe_ice>
-          <rootpe_ocn>288</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>252</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
+	<ntasks>
+	  <ntasks_atm>288</ntasks_atm>
+	  <ntasks_lnd>144</ntasks_lnd>
+	  <ntasks_rof>40</ntasks_rof>
+	  <ntasks_ice>108</ntasks_ice>
+	  <ntasks_ocn>288</ntasks_ocn>
+	  <ntasks_glc>36</ntasks_glc>
+	  <ntasks_wav>36</ntasks_wav>
+	  <ntasks_cpl>288</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>144</rootpe_ice>
+	  <rootpe_ocn>288</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>252</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
       </pes>
       <pes pesize="M3" compset="CAM.+CLM.+CICE.+POP.+">
 	<comment>For multi-instance tests</comment>
-        <ntasks>
-          <ntasks_atm>-36</ntasks_atm>
-          <ntasks_lnd>-12</ntasks_lnd>
-          <ntasks_rof>-3</ntasks_rof>
-          <ntasks_ice>-9</ntasks_ice>
-          <ntasks_ocn>-36</ntasks_ocn>
-          <ntasks_glc>-3</ntasks_glc>
-          <ntasks_wav>-3</ntasks_wav>
-          <ntasks_cpl>-36</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>144</rootpe_ice>
-          <rootpe_ocn>288</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>252</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
+	<ntasks>
+	  <ntasks_atm>-36</ntasks_atm>
+	  <ntasks_lnd>-12</ntasks_lnd>
+	  <ntasks_rof>-3</ntasks_rof>
+	  <ntasks_ice>-9</ntasks_ice>
+	  <ntasks_ocn>-36</ntasks_ocn>
+	  <ntasks_glc>-3</ntasks_glc>
+	  <ntasks_wav>-3</ntasks_wav>
+	  <ntasks_cpl>-36</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>144</rootpe_ice>
+	  <rootpe_ocn>288</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>252</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
       </pes>
     </mach>
   </grid>
@@ -1048,6 +1048,43 @@
       </pes>
     </mach>
   </grid>
+  <grid name="a%0.9x1.25_l%0.9x1.25_oi%tx0.66v1_r%r05_g%gland4_w%null_z%null_m%tx0.66v1">
+    <mach name="cheyenne">
+      <pes pesize="any" compset="any">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>576</ntasks_atm>
+	  <ntasks_lnd>288</ntasks_lnd>
+	  <ntasks_rof>288</ntasks_rof>
+	  <ntasks_ice>288</ntasks_ice>
+	  <ntasks_ocn>180</ntasks_ocn>
+	  <ntasks_glc>36</ntasks_glc>
+	  <ntasks_wav>36</ntasks_wav>
+	  <ntasks_cpl>576</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>288</rootpe_ice>
+	  <rootpe_ocn>576</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+    </mach>
+  </grid>
   <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
     <mach name="cheyenne">
       <pes pesize="any" compset="CAM.*\d_.*CLM.+CICE.+POP.+WW3">
@@ -1600,26 +1637,26 @@
   <overrides>
     <grid name="any" >
       <mach name="any" >
-        <pes pesize="any" compset="SPCAM[SM]">
-          <nthrds>
-            <nthrds_atm>1</nthrds_atm>
-            <nthrds_lnd>1</nthrds_lnd>
-            <nthrds_rof>1</nthrds_rof>
-            <nthrds_ice>1</nthrds_ice>
-            <nthrds_ocn>1</nthrds_ocn>
-            <nthrds_glc>1</nthrds_glc>
-            <nthrds_wav>1</nthrds_wav>
-            <nthrds_cpl>1</nthrds_cpl>
-          </nthrds>
-        </pes>
-        <pes pesize="any" compset="CISM1">
-          <ntasks>
-            <ntasks_glc>1</ntasks_glc>
-          </ntasks>
-          <nthrds>
-            <nthrds_glc>1</nthrds_glc>
-          </nthrds>
-        </pes>
+	<pes pesize="any" compset="SPCAM[SM]">
+	  <nthrds>
+	    <nthrds_atm>1</nthrds_atm>
+	    <nthrds_lnd>1</nthrds_lnd>
+	    <nthrds_rof>1</nthrds_rof>
+	    <nthrds_ice>1</nthrds_ice>
+	    <nthrds_ocn>1</nthrds_ocn>
+	    <nthrds_glc>1</nthrds_glc>
+	    <nthrds_wav>1</nthrds_wav>
+	    <nthrds_cpl>1</nthrds_cpl>
+	  </nthrds>
+	</pes>
+	<pes pesize="any" compset="CISM1">
+	  <ntasks>
+	    <ntasks_glc>1</ntasks_glc>
+	  </ntasks>
+	  <nthrds>
+	    <nthrds_glc>1</nthrds_glc>
+	  </nthrds>
+	</pes>
       </mach>
     </grid>
   </overrides>


### PR DESCRIPTION
Description of changes
Add B1850MOM compset, add a pelayout for cheyenne, make MOM, RTM and FMS optional components
 
Specific notes
MOM, RTM and FMS are not needed by default in the cesm2.2 release.

Contributors other than yourself, if any:

Fixes: 
User interface changes?: [ Yes ]
Users who want to use these components will have to check them out explicitly with manage_externals

Testing performed (automated tests and/or manual tests):  
PFS.f09_t061.B1850MOM.cheyenne_intel

