### PR TITLE
Fix for JG compset fixing #168

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -153,7 +153,7 @@
 
   <compset>
      <alias>J1850G</alias>
-     <lname>1850_DATM%CRU_CLM50%BGC-CROP_CICE_POP2_MOSART_CISM2%EVOLVE_SWAV</lname>
+     <lname>1850_DATM%CRUv7_CLM50%BGC-CROP_CICE_POP2_MOSART_CISM2%EVOLVE_SWAV</lname>
   </compset>
 
   <entries>


### PR DESCRIPTION
### Description of changes

Have J1850G compset use CRUv7 data rather than the older version 4 data. We removed the version 4 off local disk to save space on cheyenne and CGD.

### Specific notes

Contributors other than yourself, if any: none

Fixes: #168 

User interface changes?: No

Testing performed (automated tests and/or manual tests):

SMS_Ld5.f09_g17_gl4.J1850G.cheyenne_gnu.allactive-cism-test_coupling PASSes

