### PR TITLE
Update Externals.cfg to use uppercase repository names

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -16,7 +16,7 @@ required = True
 [cime]
 tag = cime5.8.31
 protocol = git
-repo_url = https://github.com/ESMCI/cime
+repo_url = https://github.com/ESMCI/CIME
 local_path = cime
 externals = ../Externals_cime.cfg
 required = True
@@ -24,7 +24,7 @@ required = True
 [cism]
 tag = cism2_1_69
 protocol = git
-repo_url = https://github.com/ESCOMP/cism-wrapper
+repo_url = https://github.com/ESCOMP/CISM-wrapper
 local_path = components/cism
 externals = Externals_CISM.cfg
 required = True
@@ -32,7 +32,7 @@ required = True
 [clm]
 tag = ctsm1.0.dev107
 protocol = git
-repo_url = https://github.com/ESCOMP/ctsm
+repo_url = https://github.com/ESCOMP/CTSM
 local_path = components/clm
 externals = Externals_CLM.cfg
 required = True
@@ -56,7 +56,7 @@ required = False
 [mosart]
 tag = mosart1_0_37
 protocol = git
-repo_url = https://github.com/ESCOMP/mosart
+repo_url = https://github.com/ESCOMP/MOSART
 local_path = components/mosart
 required = True
 
@@ -71,7 +71,7 @@ required = True
 [rtm]
 tag = rtm1_0_72
 protocol = git
-repo_url = https://github.com/ESCOMP/rtm
+repo_url = https://github.com/ESCOMP/RTM
 local_path = components/rtm
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -16,7 +16,7 @@ required = True
 [cime]
 tag = cime5.8.31
 protocol = git
-repo_url = https://github.com/ESMCI/CIME
+repo_url = https://github.com/ESMCI/cime
 local_path = cime
 externals = ../Externals_cime.cfg
 required = True


### PR DESCRIPTION
### Description of changes
Update Externals.cfg to use uppercase repository names

### Specific notes

Contributors other than yourself, if any:

Fixes: #128 

User interface changes?: [ No/Yes ]
[ If yes, describe what changed, and steps taken to ensure backward compatibility ]

Testing performed (automated tests and/or manual tests):
Manual manage_externals/checkout_externals -o

