### PR TITLE
adding HISTsmbb compset for smoothed BB

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [cam]
-tag = cam_cesm2_1_rel_47
+tag = cam_cesm2_1_rel_49
 protocol = git
 repo_url = https://github.com/ESCOMP/CAM
 local_path = components/cam

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -271,6 +271,16 @@
     <science_support grid="f19_g17"/>
   </compset>
 
+  <!-- Same as BHISTcmip6, but with smoothed BB and fixed SOAG forcing for SSP370 -->
+  <compset>
+    <alias>BHISTsmbb</alias>
+    <lname>HIST_CAM60%SMBB_CLM50%BGC-CROP-CMIP6DECK_CICE%CMIP6_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <science_support grid="f09_g17_gl4"/>
+    <science_support grid="f09_g17"/>
+    <science_support grid="f19_g17_gl4"/>
+    <science_support grid="f19_g17"/>
+  </compset>
+
   <compset>
     <alias>BC5L45BGC</alias>
     <lname>2000_CAM50_CLM45%BGC_CICE_POP2_MOSART_SGLC_SWAV</lname>
@@ -479,6 +489,7 @@
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="SSP585EXT_CAM60%WCTS_CLM50%BGC-CROP.*CICE.*POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3">hybrid</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="1850_CAM60_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD">hybrid</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="HIST_CAM60_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD">hybrid</value>
+        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="HIST_CAM60%SMBB_CLM50%BGC-CROP.*_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD">hybrid</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="_CAM60%4xCO2.*_CLM50%BGC-CROP-CMIP6DECK_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD">hybrid</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="_CAM60%1PCT.*_CLM50%BGC-CROP-CMIP6DECK_CICE.*_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD" >hybrid</value>
         <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="_CAM60%WCSC_CLM50%BGC-CROP_CICE_POP2%ECO.*_MOSART_CISM2%NOEVOLVE_WW3"            >hybrid</value>


### PR DESCRIPTION
### Description of changes
Adding HISTsmbb compset for CESM2-LE ensemble with smoothed BB burning and fixed SO2/SO4 forcing.

### Specific notes

Contributors other than yourself, if any:
JF Lamarque (smoothing); Simone Tilmes (Corrected SO2/SO4 ship forcing)

Fixes: [Github issue #s] And brief description of each issue.

User interface changes?: [ No/Yes ]
[ If yes, describe what changed, and steps taken to ensure backward compatibility ]

Testing performed (automated tests and/or manual tests):

