### PR TITLE
Externals_cime is no longer needed, update cmeps and cdeps hashes

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -32,7 +32,6 @@ tag = cime5.8.32
 protocol = git
 repo_url = https://github.com/ESMCI/cime
 local_path = cime
-externals = ../Externals_cime.cfg
 required = True
 
 [cism]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -13,8 +13,15 @@ repo_url = https://github.com/ESCOMP/CESM_CICE5
 local_path = components/cice
 required = True
 
+[cmeps]
+hash = dda73e0
+protocol = git
+repo_url = https://github.com/ESCOMP/CMEPS.git
+local_path = cime/src/drivers/nuopc/
+required = True
+
 [cdeps]
-hash = 45b7a85
+hash = d4394fa
 protocol = git
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps

--- a/Externals_cime.cfg
+++ b/Externals_cime.cfg
@@ -1,9 +1,0 @@
-[cmeps]
-hash = 7654038
-protocol = git
-repo_url = https://github.com/ESCOMP/CMEPS.git
-local_path = src/drivers/nuopc/
-required = False
-
-[externals_description]
-schema_version = 1.0.0


### PR DESCRIPTION
### Description of changes
Remove the Externals_cime.cfg file, no longer required.  

### Specific notes
cmeps has was updated and  moved into Externals.cfg and cdeps hash was updated

Contributors other than yourself, if any:

Fixes: [Github issue #s] And brief description of each issue.

User interface changes?: [ No/Yes ]
[ If yes, describe what changed, and steps taken to ensure backward compatibility ]

Testing performed (automated tests and/or manual tests):
The only test conducted here was a fresh checkout of the code. 
