### PR TITLE
Remove CISM1 compset and test

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -18,7 +18,7 @@
     ICE  = [CICE, DICE, SICE]
     OCN  = [DOCN, ,AQUAP, SOCN]
     ROF  = [RTM, MOSART, SROF]
-    GLC  = [CISM1, CISM2, SGLC]
+    GLC  = [CISM2, SGLC]
     WAV  = [WW3, DWAV, XWAV, SWAV]
     ESP  = [SESP]
     BGC  = optional BGC scenario
@@ -62,14 +62,6 @@
   <compset>
     <alias>B1850G</alias>
     <lname>1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%EVOLVE_WW3_BGC%BDRD</lname>
-  </compset>
-
-  <!-- Include one CISM1 compset, mainly for testing purposes, to make sure that
-       CISM1 can operate in a fully-coupled configuration. Main point is to
-       check the PE layout. -->
-  <compset>
-    <alias>B1850G1</alias>
-    <lname>1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM1%EVOLVE_WW3_BGC%BDRD</lname>
   </compset>
 
   <!-- Prognostic wave -->

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -1684,14 +1684,6 @@
 	    <nthrds_cpl>1</nthrds_cpl>
 	  </nthrds>
 	</pes>
-	<pes pesize="any" compset="CISM1">
-	  <ntasks>
-	    <ntasks_glc>1</ntasks_glc>
-	  </ntasks>
-	  <nthrds>
-	    <nthrds_glc>1</nthrds_glc>
-	  </nthrds>
-	</pes>
       </mach>
     </grid>
   </overrides>

--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -251,16 +251,6 @@
       <option name="wallclock"> 00:30:00 </option>
     </options>
   </test>
-  <test name="SMS_Ld5" grid="f19_g17" compset="B1850G1" testmods="allactive/cism/test_coupling">
-    <machines>
-      <machine name="cheyenne" compiler="gnu" category="prebeta">
-        <options>
-          <option name="wallclock">0:30:00</option>
-          <option name="comment">Include a fully-coupled test with CISM1, mainly to make sure the PE layout works</option>
-        </options>
-      </machine>
-    </machines>
-  </test>
   <test name="SMS_Ld1" grid="f19_g17" compset="B1850G" testmods="allactive/cism/test_coupling">
     <machines>
       <machine name="hobart" compiler="nag" category="prebeta"/>


### PR DESCRIPTION
### Description of changes

As of cism2_1_74, CISM1 is no longer supported

### Specific notes

Contributors other than yourself, if any: none

Fixes: none

User interface changes?: No

Testing performed (automated tests and/or manual tests): none

