### PR TITLE
Rename Greenland grid gland4 to gris4 (cesm2_3_alpha04b)

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -1048,7 +1048,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%0.9x1.25_l%0.9x1.25_oi%tx0.66v1_r%r05_g%gland4_w%null_z%null_m%tx0.66v1">
+  <grid name="a%0.9x1.25_l%0.9x1.25_oi%tx0.66v1_r%r05_g%gris4_w%null_z%null_m%tx0.66v1">
     <mach name="cheyenne">
       <pes pesize="any" compset="any">
 	<!-- B1850MOM gets about 7.9 ypd -->


### PR DESCRIPTION
### Description of changes

Rename Greenland grid gland4 to gris4

**This change needs to come in at the same time as cismwrap_2_1_80 and https://github.com/ESMCI/cime/pull/3943 - so tentatively, cesm2_3_alpha04b.**

### Specific notes

Contributors other than yourself, if any: none

Fixes: none

User interface changes?: No

Testing performed (automated tests and/or manual tests): None

