### PR TITLE
Add a new version of WW3 as an optional component

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -96,5 +96,12 @@ repo_url = https://github.com/ESCOMP/WW3-CESM
 local_path = components/ww3
 required = True
 
+[ww3dev]
+tag = dev/ncar_20210520
+protocol = git
+repo_url = https://github.com/ESCOMP/WW3-CESM
+local_path = components/ww3dev
+required = False
+
 [externals_description]
 schema_version = 1.0.01


### PR DESCRIPTION
### Description of changes

This PR adds a new version of WW3 (v.6.07) to CESM as an optional wave component, called ww3dev. Initially both ww3 and ww3dev (optional) will coexist, but once ww3dev development is finalized, it will replace the old ww3. 

Contributors other than yourself, if any: @mvertens 

Fixes: [Github issue #s] n/a

User interface changes?: [ No/Yes ] No

Testing performed (automated tests and/or manual tests): C and CMOM SMS tests with the new ww3dev component.

