### PR TITLE
Default (naive) PE layouts for AWS for 1- and 2-degree coupled runs..

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -94,6 +94,44 @@
       </pes>
     </mach>
   </grid>
+  <!-- Basic 1-node config for 2-degree runs on HPC6a nodes (by default) -->
+  <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1">
+    <mach name="aws-hpc6a">
+      <pes pesize="any" compset="any">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>-1</ntasks_atm>
+	  <ntasks_lnd>-1</ntasks_lnd>
+	  <ntasks_rof>-1</ntasks_rof>
+	  <ntasks_ice>-1</ntasks_ice>
+	  <ntasks_ocn>-1</ntasks_ocn>
+	  <ntasks_glc>-1</ntasks_glc>
+	  <ntasks_wav>36</ntasks_wav>
+	  <ntasks_cpl>-1</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+    </mach>
+  </grid>
   <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1">
     <mach name="cori-knl">
       <pes pesize="any" compset="any">
@@ -1074,6 +1112,44 @@
 	  <rootpe_ocn>260</rootpe_ocn>
 	  <rootpe_glc>0</rootpe_glc>
 	  <rootpe_wav>240</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <!-- Basic 3-node config for 1-degree runs on HPC6a nodes (by default) -->
+  <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
+    <mach name='aws-hpc6a'>
+      <pes pesize="any" compset="any">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>-3</ntasks_atm>
+	  <ntasks_lnd>-3</ntasks_lnd>
+	  <ntasks_rof>-3</ntasks_rof>
+	  <ntasks_ice>-3</ntasks_ice>
+	  <ntasks_ocn>-3</ntasks_ocn>
+	  <ntasks_glc>-3</ntasks_glc>
+	  <ntasks_wav>36</ntasks_wav>
+	  <ntasks_cpl>-3</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
 	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>


### PR DESCRIPTION
### Description of changes

### Specific notes

Contributors other than yourself, if any:

Fixes: [Github issue #s] None; just out-of-the-box default, cost-efficient layouts.

User interface changes?: [ No/Yes ] No

Testing performed (automated tests and/or manual tests): Manual run on AWS

