### PR TITLE
Update ww3dev entry in Externals.cfg for the new WW3 repo

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -140,10 +140,11 @@ local_path = components/ww3
 required = True
 
 [ww3dev]
-tag = dev/unified_220202
+tag = main_0.0.1
 protocol = git
-repo_url = https://github.com/ESCOMP/WW3-CESM
+repo_url = https://github.com/ESCOMP/WW3_interface
 local_path = components/ww3dev
+externals = Externals.cfg
 required = False
 
 [externals_description]


### PR DESCRIPTION
### Description of changes

Update ww3dev entry in Externals.cfg to point to the new WW3_interface repository.  Also add an externals entry in ww3dev to point to the core WW3 repository.


User interface changes?: No

Testing performed (automated tests and/or manual tests):

MOM6+WW3DEV ERS tests

