### PR TITLE
Remove mct tests.

### DIFF
--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -48,23 +48,7 @@
       <option name="wallclock"> 06:00:00 </option>
     </options>
   </test>
-  <test name="ERS_D_Vmct" grid="f09_g17" compset="1850_CAM60_CLM50%BGC-CROP_CICE5_POP2%ECO_MOSART_CISM2%GRIS-NOEVOLVE_WW3_BGC%BDRD" testmods="allactive/defaultio">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 06:00:00 </option>
-    </options>
-  </test>
   <test name="IRT_Ld7" grid="f09_g17" compset="BHIST" testmods="allactive/defaultio">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30:00 </option>
-    </options>
-  </test>
-  <test name="IRT_Ld7_Vmct" grid="f09_g17" compset="HIST_CAM60_CLM50%BGC-CROP_CICE5_POP2%ECO_MOSART_CISM2%GRIS-NOEVOLVE_WW3_BGC%BDRD" testmods="allactive/defaultio">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>
@@ -142,15 +126,6 @@
     </options>
   </test>
   <test name="PET_PM" grid="f19_g17" compset="B1850" testmods="allactive/defaultiomi">
-    <machines>
-      <machine name="cheyenne" compiler="gnu" category="prealpha"/>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 01:30:00 </option>
-    </options>
-  </test>
-  <test name="PET_PM_Vmct" grid="f19_g17" compset="1850_CAM60_CLM50%BGC-CROP_CICE5_POP2%ECO_MOSART_CISM2%GRIS-NOEVOLVE_WW3_BGC%BDRD" testmods="allactive/defaultiomi">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="prealpha"/>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>


### PR DESCRIPTION
Remove mct tests from the tests lists that are failing.  There are no plans to fix these tests since 
mct is being deprecated. 
