### PR TITLE
add derecho pelayouts remove retired systems

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -40,23 +40,143 @@
     </mach>
   </grid>
 
-  <grid name="any">
-    <mach name="cori-knl">
-      <pes pesize="any" compset="any">
-	<comment>use 2 hyperthreads per core</comment>
+  <grid name="a%ne30np4.pg3_l%ne30np4.pg3_oi%tx2_3v2">
+    <mach name="derecho">
+      <pes pesize="XL" compset="CAM.*%LT.*MOM6">
+	<comment>20 ypd/ 7100 pe-hrs/simyr expected</comment>
+	<ntasks>
+	  <ntasks_atm>5400</ntasks_atm>
+	  <ntasks_lnd>939</ntasks_lnd>
+	  <ntasks_rof>64</ntasks_rof>
+	  <ntasks_ice>4397</ntasks_ice>
+	  <ntasks_ocn>488</ntasks_ocn>
+	  <ntasks_glc>64</ntasks_glc>
+	  <ntasks_wav>64</ntasks_wav>
+	  <ntasks_cpl>5400</ntasks_cpl>
+	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>
-	  <nthrds_lnd>2</nthrds_lnd>
-	  <nthrds_rof>2</nthrds_rof>
-	  <nthrds_ice>2</nthrds_ice>
-	  <nthrds_ocn>2</nthrds_ocn>
-	  <nthrds_glc>2</nthrds_glc>
-	  <nthrds_wav>2</nthrds_wav>
-	  <nthrds_cpl>2</nthrds_cpl>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>1003</rootpe_ice>
+	  <rootpe_ocn>5400</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+      <pes pesize="L" compset="CAM.*%LT.*MOM6">
+	<comment>13.9 ypd/ 5300 pe-hrs/simyr expected</comment>
+	<ntasks>
+	  <ntasks_atm>2700</ntasks_atm>
+	  <ntasks_lnd>896</ntasks_lnd>
+	  <ntasks_rof>32</ntasks_rof>
+	  <ntasks_ice>1772</ntasks_ice>
+	  <ntasks_ocn>372</ntasks_ocn>
+	  <ntasks_glc>32</ntasks_glc>
+	  <ntasks_wav>32</ntasks_wav>
+	  <ntasks_cpl>2700</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>896</rootpe_rof>
+	  <rootpe_ice>928</rootpe_ice>
+	  <rootpe_ocn>2700</rootpe_ocn>
+	  <rootpe_glc>896</rootpe_glc>
+	  <rootpe_wav>896</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+      <pes pesize="M" compset="CAM.*%LT.*MOM6">
+	<comment>10 ypd/ 5100 pe-hrs/simyr expected</comment>
+	<ntasks>
+	  <ntasks_atm>1920</ntasks_atm>
+	  <ntasks_lnd>640</ntasks_lnd>
+	  <ntasks_rof>64</ntasks_rof>
+	  <ntasks_ice>1216</ntasks_ice>
+	  <ntasks_ocn>256</ntasks_ocn>
+	  <ntasks_glc>64</ntasks_glc>
+	  <ntasks_wav>64</ntasks_wav>
+	  <ntasks_cpl>1920</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>640</rootpe_rof>
+	  <rootpe_ice>704</rootpe_ice>
+	  <rootpe_ocn>1920</rootpe_ocn>
+	  <rootpe_glc>640</rootpe_glc>
+	  <rootpe_wav>640</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+      <pes pesize="S" compset="CAM.*%LT.*MOM6">
+	<comment>2.9 ypd/ 4185 pe-hrs/simyr expected</comment>
+	<ntasks>
+	  <ntasks_atm>448</ntasks_atm>
+	  <ntasks_lnd>208</ntasks_lnd>
+	  <ntasks_rof>16</ntasks_rof>
+	  <ntasks_ice>224</ntasks_ice>
+	  <ntasks_ocn>64</ntasks_ocn>
+	  <ntasks_glc>16</ntasks_glc>
+	  <ntasks_wav>16</ntasks_wav>
+	  <ntasks_cpl>448</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>16</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>224</rootpe_ice>
+	  <rootpe_ocn>448</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
       </pes>
     </mach>
   </grid>
+
   <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1">
     <mach name="any">
       <pes pesize="any" compset="any">
@@ -80,43 +200,6 @@
 	  <nthrds_glc>1</nthrds_glc>
 	  <nthrds_wav>1</nthrds_wav>
 	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>-2</rootpe_ice>
-	  <rootpe_ocn>-4</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1">
-    <mach name="cori-knl">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-4</ntasks_atm>
-	  <ntasks_lnd>-2</ntasks_lnd>
-	  <ntasks_rof>-2</ntasks_rof>
-	  <ntasks_ice>-2</ntasks_ice>
-	  <ntasks_ocn>-2</ntasks_ocn>
-	  <ntasks_glc>-1</ntasks_glc>
-	  <ntasks_wav>-1</ntasks_wav>
-	  <ntasks_cpl>-4</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>
-	  <nthrds_lnd>2</nthrds_lnd>
-	  <nthrds_rof>2</nthrds_rof>
-	  <nthrds_ice>2</nthrds_ice>
-	  <nthrds_ocn>2</nthrds_ocn>
-	  <nthrds_glc>2</nthrds_glc>
-	  <nthrds_wav>2</nthrds_wav>
-	  <nthrds_cpl>2</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -196,43 +279,6 @@
 	  <rootpe_ocn>288</rootpe_ocn>
 	  <rootpe_glc>0</rootpe_glc>
 	  <rootpe_wav>252</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1">
-    <mach name="cori-haswell">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-16</ntasks_atm>
-	  <ntasks_lnd>-9</ntasks_lnd>
-	  <ntasks_rof>-9</ntasks_rof>
-	  <ntasks_ice>-7</ntasks_ice>
-	  <ntasks_ocn>-1</ntasks_ocn>
-	  <ntasks_glc>-1</ntasks_glc>
-	  <ntasks_wav>-1</ntasks_wav>
-	  <ntasks_cpl>-16</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>
-	  <nthrds_lnd>8</nthrds_lnd>
-	  <nthrds_rof>8</nthrds_rof>
-	  <nthrds_ice>8</nthrds_ice>
-	  <nthrds_ocn>8</nthrds_ocn>
-	  <nthrds_glc>8</nthrds_glc>
-	  <nthrds_wav>8</nthrds_wav>
-	  <nthrds_cpl>8</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>-9</rootpe_ice>
-	  <rootpe_ocn>-16</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
 	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
@@ -351,7 +397,7 @@
   </grid>
   <grid name="a%ne30np4.+l%ne30np4.+oi%tx2_3v2" >
     <mach name="cheyenne">
-      <pes pesize="any" compset="CAM%DEV%LT.+CLM.+CICE.+MOM6.+WW3">
+      <pes pesize="any" compset="CAM.*%LT.+CLM.+CICE.+MOM6.+WW3">
         <comment>none</comment>
         <ntasks>
           <ntasks_atm>1800</ntasks_atm>
@@ -383,80 +429,6 @@
           <rootpe_wav>1</rootpe_wav>
           <rootpe_cpl>0</rootpe_cpl>
         </rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%ne30np4.+l%ne30np4.+oi%gx1" >
-    <mach name="mira">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>2600</ntasks_atm>
-	  <ntasks_lnd>144</ntasks_lnd>
-	  <ntasks_rof>144</ntasks_rof>
-	  <ntasks_ice>2456</ntasks_ice>
-	  <ntasks_ocn>192</ntasks_ocn>
-	  <ntasks_glc>1</ntasks_glc>
-	  <ntasks_wav>160</ntasks_wav>
-	  <ntasks_cpl>2600</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>
-	  <nthrds_lnd>8</nthrds_lnd>
-	  <nthrds_ice>8</nthrds_ice>
-	  <nthrds_rof>8</nthrds_rof>
-	  <nthrds_ocn>8</nthrds_ocn>
-	  <nthrds_glc>8</nthrds_glc>
-	  <nthrds_wav>8</nthrds_wav>
-	  <nthrds_cpl>8</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_ice>144</rootpe_ice>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ocn>2600</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%ne30np4.+l%ne30np4.+oi%gx1" >
-    <mach name="edison|eos">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>960</ntasks_atm>
-	  <ntasks_lnd>48</ntasks_lnd>
-	  <ntasks_rof>48</ntasks_rof>
-	  <ntasks_ice>912</ntasks_ice>
-	  <ntasks_ocn>48</ntasks_ocn>
-	  <ntasks_glc>1</ntasks_glc>
-	  <ntasks_wav>160</ntasks_wav>
-	  <ntasks_cpl>960</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>
-	  <nthrds_lnd>4</nthrds_lnd>
-	  <nthrds_rof>4</nthrds_rof>
-	  <nthrds_ice>4</nthrds_ice>
-	  <nthrds_ocn>4</nthrds_ocn>
-	  <nthrds_glc>4</nthrds_glc>
-	  <nthrds_wav>4</nthrds_wav>
-	  <nthrds_cpl>4</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>48</rootpe_ice>
-	  <rootpe_ocn>960</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
       </pes>
     </mach>
   </grid>
@@ -498,43 +470,6 @@
     </mach>
   </grid>
   <grid name="a%ne120np4.+l%ne120np4.+oi%tx0.1v2">
-    <mach name="mira">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>12384</ntasks_atm>
-	  <ntasks_lnd>96</ntasks_lnd>
-	  <ntasks_rof>96</ntasks_rof>
-	  <ntasks_ice>12288</ntasks_ice>
-	  <ntasks_ocn>4000</ntasks_ocn>
-	  <ntasks_glc>1</ntasks_glc>
-	  <ntasks_wav>160</ntasks_wav>
-	  <ntasks_cpl>12384</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>
-	  <nthrds_lnd>8</nthrds_lnd>
-	  <nthrds_rof>8</nthrds_rof>
-	  <nthrds_ice>8</nthrds_ice>
-	  <nthrds_ocn>8</nthrds_ocn>
-	  <nthrds_wav>8</nthrds_wav>
-	  <nthrds_cpl>8</nthrds_cpl>
-	  <nthrds_glc>8</nthrds_glc>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>96</rootpe_ice>
-	  <rootpe_ocn>12384</rootpe_ocn>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	  <rootpe_glc>0</rootpe_glc>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%ne120np4.+l%ne120np4.+oi%tx0.1v2">
     <mach name="stampede|titan" >
       <pes pesize="any" compset="any">
 	<comment>none</comment>
@@ -564,43 +499,6 @@
 	  <rootpe_rof>0</rootpe_rof>
 	  <rootpe_ice>0</rootpe_ice>
 	  <rootpe_ocn>1440</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%ne240np4.+l%ne240.+oi%gx1"  >
-    <mach name="edison|eos">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>9600</ntasks_atm>
-	  <ntasks_lnd>8640</ntasks_lnd>
-	  <ntasks_rof>600</ntasks_rof>
-	  <ntasks_ice>960</ntasks_ice>
-	  <ntasks_ocn>960</ntasks_ocn>
-	  <ntasks_glc>960</ntasks_glc>
-	  <ntasks_wav>160</ntasks_wav>
-	  <ntasks_cpl>960</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>
-	  <nthrds_lnd>4</nthrds_lnd>
-	  <nthrds_rof>4</nthrds_rof>
-	  <nthrds_ice>4</nthrds_ice>
-	  <nthrds_ocn>4</nthrds_ocn>
-	  <nthrds_glc>4</nthrds_glc>
-	  <nthrds_wav>4</nthrds_wav>
-	  <nthrds_cpl>4</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>8640</rootpe_ice>
-	  <rootpe_ocn>9600</rootpe_ocn>
 	  <rootpe_glc>0</rootpe_glc>
 	  <rootpe_wav>0</rootpe_wav>
 	  <rootpe_cpl>0</rootpe_cpl>
@@ -639,43 +537,6 @@
 	  <rootpe_cpl>0</rootpe_cpl>
 	  <rootpe_glc>0</rootpe_glc>
 	  <rootpe_wav>0</rootpe_wav>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1">
-    <mach name="mira">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-64</ntasks_atm>
-	  <ntasks_lnd>-16</ntasks_lnd>
-	  <ntasks_rof>-16</ntasks_rof>
-	  <ntasks_ice>-48</ntasks_ice>
-	  <ntasks_cpl>-64</ntasks_cpl>
-	  <ntasks_glc>-1</ntasks_glc>
-	  <ntasks_wav>-1</ntasks_wav>
-	  <ntasks_ocn>-16</ntasks_ocn>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>
-	  <nthrds_lnd>8</nthrds_lnd>
-	  <nthrds_rof>8</nthrds_rof>
-	  <nthrds_ice>8</nthrds_ice>
-	  <nthrds_cpl>8</nthrds_cpl>
-	  <nthrds_glc>8</nthrds_glc>
-	  <nthrds_wav>8</nthrds_wav>
-	  <nthrds_ocn>8</nthrds_ocn>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>-16</rootpe_ice>
-	  <rootpe_cpl>0</rootpe_cpl>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_ocn>-64</rootpe_ocn>
 	</rootpe>
       </pes>
     </mach>
@@ -900,117 +761,6 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1" >
-    <mach name="edison|eos">
-      <pes pesize="any" compset="CAM.+CLM.+CICE.+POP">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>96</ntasks_atm>
-	  <ntasks_lnd>96</ntasks_lnd>
-	  <ntasks_rof>96</ntasks_rof>
-	  <ntasks_ice>96</ntasks_ice>
-	  <ntasks_ocn>96</ntasks_ocn>
-	  <ntasks_glc>96</ntasks_glc>
-	  <ntasks_wav>96</ntasks_wav>
-	  <ntasks_cpl>96</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>
-	  <nthrds_lnd>4</nthrds_lnd>
-	  <nthrds_rof>4</nthrds_rof>
-	  <nthrds_ice>4</nthrds_ice>
-	  <nthrds_ocn>4</nthrds_ocn>
-	  <nthrds_glc>4</nthrds_glc>
-	  <nthrds_wav>4</nthrds_wav>
-	  <nthrds_cpl>4</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%1.9x2.5_l%1.9x2.5_oi%gx1" >
-    <mach name="edison|eos">
-      <pes pesize="any" compset="CAM.+WISO.+CLM.+CICE.+POP">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>640</ntasks_atm>
-	  <ntasks_lnd>96</ntasks_lnd>
-	  <ntasks_rof>96</ntasks_rof>
-	  <ntasks_ice>544</ntasks_ice>
-	  <ntasks_ocn>96</ntasks_ocn>
-	  <ntasks_glc>180</ntasks_glc>
-	  <ntasks_wav>160</ntasks_wav>
-	  <ntasks_cpl>640</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>2</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>2</nthrds_glc>
-	  <nthrds_wav>2</nthrds_wav>
-	  <nthrds_cpl>2</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>544</rootpe_lnd>
-	  <rootpe_rof>544</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>640</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1" >
-    <mach name="edison|eos">
-      <pes pesize="any" compset="CAM.+CLM.+CICE_DOCN%SOM">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>96</ntasks_atm>
-	  <ntasks_lnd>96</ntasks_lnd>
-	  <ntasks_rof>96</ntasks_rof>
-	  <ntasks_ice>96</ntasks_ice>
-	  <ntasks_ocn>96</ntasks_ocn>
-	  <ntasks_glc>96</ntasks_glc>
-	  <ntasks_wav>96</ntasks_wav>
-	  <ntasks_cpl>96</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>
-	  <nthrds_lnd>4</nthrds_lnd>
-	  <nthrds_rof>4</nthrds_rof>
-	  <nthrds_ice>4</nthrds_ice>
-	  <nthrds_ocn>4</nthrds_ocn>
-	  <nthrds_glc>4</nthrds_glc>
-	  <nthrds_wav>4</nthrds_wav>
-	  <nthrds_cpl>4</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
   <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
     <mach name='any'>
       <pes pesize="any" compset="any">
@@ -1034,43 +784,6 @@
 	  <nthrds_glc>1</nthrds_glc>
 	  <nthrds_wav>1</nthrds_wav>
 	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>-4</rootpe_ice>
-	  <rootpe_ocn>-8</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
-    <mach name='cori-knl'>
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-8</ntasks_atm>
-	  <ntasks_lnd>-4</ntasks_lnd>
-	  <ntasks_rof>-4</ntasks_rof>
-	  <ntasks_ice>-4</ntasks_ice>
-	  <ntasks_ocn>-1</ntasks_ocn>
-	  <ntasks_glc>-8</ntasks_glc>
-	  <ntasks_wav>-8</ntasks_wav>
-	  <ntasks_cpl>-8</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>
-	  <nthrds_lnd>2</nthrds_lnd>
-	  <nthrds_rof>2</nthrds_rof>
-	  <nthrds_ice>2</nthrds_ice>
-	  <nthrds_ocn>2</nthrds_ocn>
-	  <nthrds_glc>2</nthrds_glc>
-	  <nthrds_wav>2</nthrds_wav>
-	  <nthrds_cpl>2</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -1398,153 +1111,6 @@
 	</rootpe>
       </pes>
     </mach>
-    <mach name="edison">
-      <pes pesize="any" compset="CAM.+CLM.+CICE.+POP.+WW3">
-	<comment>about 17ypd expected</comment>
-	<ntasks>
-	  <ntasks_atm>-50</ntasks_atm>
-	  <ntasks_lnd>-30</ntasks_lnd>
-	  <ntasks_rof>-30</ntasks_rof>
-	  <ntasks_ice>-18</ntasks_ice>
-	  <ntasks_ocn>-20</ntasks_ocn>
-	  <ntasks_glc>-30</ntasks_glc>
-	  <ntasks_wav>-2</ntasks_wav>
-	  <ntasks_cpl>-50</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>
-	  <nthrds_lnd>4</nthrds_lnd>
-	  <nthrds_rof>4</nthrds_rof>
-	  <nthrds_ice>4</nthrds_ice>
-	  <nthrds_ocn>4</nthrds_ocn>
-	  <nthrds_glc>4</nthrds_glc>
-	  <nthrds_wav>4</nthrds_wav>
-	  <nthrds_cpl>4</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>-30</rootpe_ice>
-	  <rootpe_ocn>-50</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>-48</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
-    <mach name='cori-haswell'>
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-16</ntasks_atm>
-	  <ntasks_lnd>-9</ntasks_lnd>
-	  <ntasks_rof>-9</ntasks_rof>
-	  <ntasks_ice>-7</ntasks_ice>
-	  <ntasks_ocn>-1</ntasks_ocn>
-	  <ntasks_glc>-1</ntasks_glc>
-	  <ntasks_wav>-1</ntasks_wav>
-	  <ntasks_cpl>-16</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>
-	  <nthrds_lnd>8</nthrds_lnd>
-	  <nthrds_rof>8</nthrds_rof>
-	  <nthrds_ice>8</nthrds_ice>
-	  <nthrds_ocn>8</nthrds_ocn>
-	  <nthrds_glc>8</nthrds_glc>
-	  <nthrds_wav>8</nthrds_wav>
-	  <nthrds_cpl>8</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>-9</rootpe_ice>
-	  <rootpe_ocn>-16</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
-    <!-- NTASKS_ATM is maxed out NTASKS_OCN overly large to fit 256 nodes on mira -->
-    <mach name='mira'>
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-208</ntasks_atm>
-	  <ntasks_lnd>-32</ntasks_lnd>
-	  <ntasks_rof>-32</ntasks_rof>
-	  <ntasks_ice>-80</ntasks_ice>
-	  <ntasks_ocn>-48</ntasks_ocn>
-	  <ntasks_glc>-1</ntasks_glc>
-	  <ntasks_wav>-1</ntasks_wav>
-	  <ntasks_cpl>-208</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>
-	  <nthrds_lnd>8</nthrds_lnd>
-	  <nthrds_rof>8</nthrds_rof>
-	  <nthrds_ice>8</nthrds_ice>
-	  <nthrds_ocn>8</nthrds_ocn>
-	  <nthrds_glc>8</nthrds_glc>
-	  <nthrds_wav>8</nthrds_wav>
-	  <nthrds_cpl>8</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>-32</rootpe_rof>
-	  <rootpe_ice>-64</rootpe_ice>
-	  <rootpe_ocn>-208</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
-    <mach name="edison|eos">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>960</ntasks_atm>
-	  <ntasks_lnd>48</ntasks_lnd>
-	  <ntasks_rof>48</ntasks_rof>
-	  <ntasks_ice>912</ntasks_ice>
-	  <ntasks_ocn>48</ntasks_ocn>
-	  <ntasks_glc>1</ntasks_glc>
-	  <ntasks_wav>160</ntasks_wav>
-	  <ntasks_cpl>960</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>
-	  <nthrds_lnd>4</nthrds_lnd>
-	  <nthrds_rof>4</nthrds_rof>
-	  <nthrds_ice>4</nthrds_ice>
-	  <nthrds_ocn>4</nthrds_ocn>
-	  <nthrds_glc>4</nthrds_glc>
-	  <nthrds_wav>4</nthrds_wav>
-	  <nthrds_cpl>4</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>48</rootpe_ice>
-	  <rootpe_ocn>960</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
   </grid>
   <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
     <mach name="stampede|titan" >
@@ -1576,81 +1142,6 @@
 	  <rootpe_rof>0</rootpe_rof>
 	  <rootpe_ice>64</rootpe_ice>
 	  <rootpe_ocn>384</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
-    <mach name="laramie">
-      <pes pesize="M" compset="CAM.+CLM.+CICE.+POP.+">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-8</ntasks_atm>
-	  <ntasks_lnd>-6</ntasks_lnd>
-	  <ntasks_rof>-6</ntasks_rof>
-	  <ntasks_ice>-2</ntasks_ice>
-	  <ntasks_ocn>-2</ntasks_ocn>
-	  <ntasks_glc>1</ntasks_glc>
-	  <ntasks_wav>-4</ntasks_wav>
-	  <ntasks_cpl>-8</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>
-	  <nthrds_lnd>2</nthrds_lnd>
-	  <nthrds_rof>2</nthrds_rof>
-	  <nthrds_ice>2</nthrds_ice>
-	  <nthrds_ocn>2</nthrds_ocn>
-	  <nthrds_glc>2</nthrds_glc>
-	  <nthrds_wav>2</nthrds_wav>
-	  <nthrds_cpl>2</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>-6</rootpe_ice>
-	  <rootpe_ocn>-8</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-
-  <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
-    <mach name="edison|eos">
-      <pes pesize="any" compset="CAM.+CLM.+CICE.+DOCN%SOM">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>192</ntasks_atm>
-	  <ntasks_lnd>192</ntasks_lnd>
-	  <ntasks_rof>192</ntasks_rof>
-	  <ntasks_ice>192</ntasks_ice>
-	  <ntasks_ocn>192</ntasks_ocn>
-	  <ntasks_glc>192</ntasks_glc>
-	  <ntasks_wav>160</ntasks_wav>
-	  <ntasks_cpl>192</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>
-	  <nthrds_lnd>4</nthrds_lnd>
-	  <nthrds_rof>4</nthrds_rof>
-	  <nthrds_ice>4</nthrds_ice>
-	  <nthrds_ocn>4</nthrds_ocn>
-	  <nthrds_glc>4</nthrds_glc>
-	  <nthrds_wav>4</nthrds_wav>
-	  <nthrds_cpl>4</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
 	  <rootpe_glc>0</rootpe_glc>
 	  <rootpe_wav>0</rootpe_wav>
 	  <rootpe_cpl>0</rootpe_cpl>
@@ -1695,43 +1186,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne120.+l%ne120.+oi%gx1" >
-    <mach name="bluewaters">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>3200</ntasks_atm>
-	  <ntasks_lnd>1600</ntasks_lnd>
-	  <ntasks_rof>1600</ntasks_rof>
-	  <ntasks_ice>1600</ntasks_ice>
-	  <ntasks_ocn>32</ntasks_ocn>
-	  <ntasks_glc>3200</ntasks_glc>
-	  <ntasks_wav>160</ntasks_wav>
-	  <ntasks_cpl>3200</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>
-	  <nthrds_lnd>2</nthrds_lnd>
-	  <nthrds_rof>2</nthrds_rof>
-	  <nthrds_ice>2</nthrds_ice>
-	  <nthrds_ocn>2</nthrds_ocn>
-	  <nthrds_glc>2</nthrds_glc>
-	  <nthrds_wav>2</nthrds_wav>
-	  <nthrds_cpl>2</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>1600</rootpe_ice>
-	  <rootpe_ocn>3200</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
+
 
   <!-- J compset (all active except data atmosphere)
        Laid out as follows:


### PR DESCRIPTION
### Description of changes
Add pelayouts for ne30pg3_t232.BLT1850_v0c on derecho

### Specific notes

Contributors other than yourself, if any:

Fixes:

User interface changes?:  No

Testing performed (automated tests and/or manual tests):
PFS.ne30pg3_t232.BLT1850_v0c.derecho_intel

All four new pelayouts were added to the timing table at https://csegweb.cgd.ucar.edu/timing/cgi-bin/timings.cgi?a=s