### PR TITLE
NTASK fixes for derecho prealpha tests.

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -772,7 +772,7 @@
 	  <ntasks_ice>-4</ntasks_ice>
 	  <ntasks_ocn>-1</ntasks_ocn>
 	  <ntasks_glc>-8</ntasks_glc>
-	  <ntasks_wav>-8</ntasks_wav>
+	  <ntasks_wav>-2</ntasks_wav>
 	  <ntasks_cpl>-8</ntasks_cpl>
 	</ntasks>
 	<nthrds>

--- a/cime_config/testmods_dirs/allactive/defaultiomi/shell_commands
+++ b/cime_config/testmods_dirs/allactive/defaultiomi/shell_commands
@@ -1,1 +1,1 @@
-./xmlchange NTASKS_OCN=144
+./xmlchange NTASKS_OCN=-2


### PR DESCRIPTION
### Description of changes
There were some tests on derecho that failed due to the PES layouts.

Reduce the number of default nodes for WAV at 1 deg configuration.
Set the allactive-defaultiomi testmod NTASKS for ocn to 2 nodes.

### Specific notes

Contributors other than yourself, if any:

Fixes: [Github issue #s] And brief description of each issue.

User interface changes?: [ No/Yes ]
[ If yes, describe what changed, and steps taken to ensure backward compatibility ]

Testing performed (automated tests and/or manual tests):
PFS_Ld1.f09_g17.B1850.derecho_intel.allactive-defaultio
MCC.f19_g17.B1850.derecho_intel.allactive-defaultiomi.defaultpes
MCC.f19_g17.B1850.cheyenne_intel.allactive-defaultiomi
