### PR TITLE
PES fix for ne30pg3_t232 BLT1850_v0c on cheyenne

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -401,8 +401,8 @@
         <comment>none</comment>
         <ntasks>
           <ntasks_atm>1800</ntasks_atm>
-          <ntasks_lnd>724</ntasks_lnd>
-          <ntasks_rof>724</ntasks_rof>
+          <ntasks_lnd>720</ntasks_lnd>
+          <ntasks_rof>720</ntasks_rof>
           <ntasks_ice>1080</ntasks_ice>
           <ntasks_ocn>324</ntasks_ocn>
           <ntasks_glc>36</ntasks_glc>
@@ -423,7 +423,7 @@
           <rootpe_atm>0</rootpe_atm>
           <rootpe_lnd>0</rootpe_lnd>
           <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>724</rootpe_ice>
+          <rootpe_ice>720</rootpe_ice>
           <rootpe_ocn>1800</rootpe_ocn>
           <rootpe_glc>0</rootpe_glc>
           <rootpe_wav>1</rootpe_wav>


### PR DESCRIPTION
### Description of changes
NTASKS_LND=NTASKS_ROF=ROOTPE_ICE=724 for ne30pg3_t232 BLT1850_v0c on cheyenne.  The correct value
should be 720 in order to use the all 36 tasks on a node.

### Specific notes

Contributors other than yourself, if any:

Fixes:  Partially address #228.  There's no significant speed up.  

User interface changes?: [ No/Yes ]
[ If yes, describe what changed, and steps taken to ensure backward compatibility ]

Testing performed (automated tests and/or manual tests):

