### PR TITLE
Cesm3.0 more marbl

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -59,6 +59,11 @@
   </compset>
 
   <compset>
+    <alias>BMT1850_MARBL</alias>
+    <lname>1850_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6%MARBL-BIO_MOSART_DGLC%NOEVOLVE_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>BMTHIST</alias>
     <lname>HIST_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_SWAV</lname>
   </compset>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -82,7 +82,7 @@
 	  <ntasks_lnd>1816</ntasks_lnd>
 	  <ntasks_rof>1816</ntasks_rof>
 	  <ntasks_ice>3584</ntasks_ice>
-	  <ntasks_ocn>1816</ntasks_ocn>
+	  <ntasks_ocn>1768</ntasks_ocn>
 	  <ntasks_glc>4</ntasks_glc>
 	  <ntasks_wav>1</ntasks_wav>
 	  <ntasks_cpl>5400</ntasks_cpl>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -75,6 +75,39 @@
 	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
+      <pes pesize="M" compset="CAM.*%MT.*MOM6%[^_]*MARBL-BIO">
+	<comment></comment>
+	<ntasks>
+	  <ntasks_atm>5400</ntasks_atm>
+	  <ntasks_lnd>1816</ntasks_lnd>
+	  <ntasks_rof>1816</ntasks_rof>
+	  <ntasks_ice>3584</ntasks_ice>
+	  <ntasks_ocn>1816</ntasks_ocn>
+	  <ntasks_glc>4</ntasks_glc>
+	  <ntasks_wav>1</ntasks_wav>
+	  <ntasks_cpl>5400</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>3584</rootpe_lnd>
+	  <rootpe_rof>3584</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>5400</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
       <pes pesize="XL" compset="CAM.*%LT.*MOM6(?!.*%MARBL-BIO)">
 	<comment>20 ypd/ 7100 pe-hrs/simyr expected</comment>
 	<ntasks>


### PR DESCRIPTION
### Description of changes

Add `BMT1850_MARBL` compset, use existing MT pe-layout for non-MARBL configurations, and introduce new MT+MARBL pe-layout

### Specific notes

I told @jedwards4b already, but there's an issue with the existing MT layout: the ocean has 408 cores, starting at 5400, so the run uses 5808 cores -- that's 45 full nodes plus 48 cores on a 46th node. NTASKS_OCN should either get bumped up to 488 or dropped to 360.

Contributors other than yourself, if any:

Fixes: [Github issue #s] N/A

User interface changes?: No

Testing performed (automated tests and/or manual tests):

Ran PFS tests to ensure `BMT1850` and `BMT1850_MARBL` both get expected layouts.