### PR TITLE
Add CUPiD v0.1.0 to CESMROOT/tools

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -32,7 +32,7 @@
         fxDONOTUSEurl = https://github.com/ESMCI/ccs_config_cesm.git
         fxtag = ccs_config_cesm1.0.4
         fxrequired = ToplevelRequired
-        
+
 [submodule "cime"]
         path = cime
         url = https://github.com/ESMCI/cime
@@ -116,7 +116,7 @@
         fxDONOTUSEurl = https://github.com/ESCOMP/WW3_interface
         fxtag = ww3i_0.0.2
         fxrequired = ToplevelRequired
-                
+
 [submodule "mizuroute"]
         path = components/mizuroute
         url = https://github.com/ESCOMP/mizuRoute
@@ -151,3 +151,10 @@
         fxDONOTUSEurl = https://github.com/NCAR/PyCECT
         fxrequired = ToplevelRequired
         fxtag = 3.2.2
+
+[submodule "tools/CUPiD"]
+        path = tools/CUPiD
+        url = https://github.com/NCAR/CUPiD.git
+        fxDONOTUSEurl = https://github.com/NCAR/CUPiD.git
+        fxrequired = ToplevelRequired
+        fxtag = v0.1.0


### PR DESCRIPTION
### Description of changes

Add CUPiD to the `tools/` directory

### Specific notes

Having CUPiD in the CESM tree will make it easier to incorporate in the [CESM Workflow](https://github.com/ESMCI/ccs_config_cesm/pull/176)

Contributors other than yourself, if any: @teaganking and @ingridc2051 have done a lot of the heavy lifting towards incorporating CUPiD into CESM

Fixes: N/A

User interface changes?: No

Testing performed (automated tests and/or manual tests): None (will start testing with the ccs_config_cesm branch soon)

