### PR TITLE
Add some restart tests

### DIFF
--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -8,6 +8,38 @@
       <option name="wallclock"> 01:00:00 </option>
     </options>
   </test>
+  <test name="ERS_Ld5" grid="ne30pg3_t232" compset="BLT1850" testmods="allactive/defaultio">
+    <machines>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00:00 </option>
+    </options>
+  </test>
+  <test name="ERS_Ld5" grid="ne30pg3_t232" compset="BLTHIST" testmods="allactive/defaultio">
+    <machines>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00:00 </option>
+    </options>
+  </test>
+  <test name="ERS_Ld5" grid="ne30pg3_t232" compset="BLT1850" testmods="allactive/decstart">
+    <machines>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00:00 </option>
+    </options>
+  </test>
+  <test name="ERS_Ld5" grid="ne30pg3_t232" compset="BLTHIST" testmods="allactive/decstart">
+    <machines>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00:00 </option>
+    </options>
+  </test>
 
   <test name="ERI" grid="ne30pg3_t232" compset="BLT1850" testmods="allactive/defaultio">
     <machines>

--- a/cime_config/testmods_dirs/allactive/decstart/include_user_mods
+++ b/cime_config/testmods_dirs/allactive/decstart/include_user_mods
@@ -1,0 +1,1 @@
+../defaultio

--- a/cime_config/testmods_dirs/allactive/decstart/shell_commands
+++ b/cime_config/testmods_dirs/allactive/decstart/shell_commands
@@ -1,0 +1,2 @@
+./xmlchange RUN_STARTDATE=2001-12-30
+./xmlchange CLM_BLDNML_OPTS=-ignore_warnings --append


### PR DESCRIPTION
### Description of changes

Doing some investigation of https://github.com/ESCOMP/CMEPS/issues/44, it felt like we should have more restart tests of B compsets, both starting at the typical January 1 time and crossing the year boundary. The latter uses a decstart testmod taken from CTSM.

I have run these four new tests from cesm3_0_alpha03b. Current status is:
1. ERS_Ld5.ne30pg3_t232.BLT1850.derecho_intel.allactive-defaultio: passes
2. ERS_Ld5.ne30pg3_t232.BLTHIST.derecho_intel.allactive-defaultio: run fails in CAM with `find_times: all(all_data_times(:) > time) /glade/campaign/cesm/cesmdata/inputdata/atm/cam/chem/ubc/f.e21.FWHISTBgcCrop.f09_f09_mg17.CMIP6-AMIP-WACCM.ensAvg123.cam.h0zm.UBC.195001-201412_c220322.nc`
3. ERS_Ld5.ne30pg3_t232.BLT1850.derecho_intel.allactive-decstart: fails COMPARE_base_rest, but passes with the recent DGLC fix from @mvertens, using cdeps1.0.51
4. ERS_Ld5.ne30pg3_t232.BLTHIST.derecho_intel.allactive-decstart: fails COMPARE_base_rest, but passes with the recent DGLC fix from @mvertens, using cdeps1.0.51

**I added the tests that I ran, since I know their status, but it might be worth tweaking these to get more diversity in compilers and compsets. For example, we could stick with having 4 new tests, but do: (1) BLT1850 defaultio with intel (same as the current (1)); (2) BLTHIST defaultio with gnu (i.e., change the current (2) to use gnu); (3) BMT1850 decstart with gnu (i.e., change the current (3) to BMT and gnu); (4) BMTHIST decstart with intel (i.e., change the current (4) to BMT). @fischer-ncar can I leave this decision up to you, as part of getting good coverage of both compsets and compilers in our prealpha testing?**

### Specific notes

Contributors other than yourself, if any:

Fixes: none

User interface changes?: No

Testing performed (automated tests and/or manual tests): See notes above