### PR TITLE
Set LND_SETS_DUST_EMIS_DRV_FLDS to avoid conflict between cam and clm.

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -104,6 +104,11 @@
 	<value compset="2013[CE]?_"     >2013-01-01</value>
       </values>
     </entry>
+    <entry id="LND_SETS_DUST_EMIS_DRV_FLDS">
+      <values match="first">
+      <value compset="_CAM7.*_CLM6">FALSE</value>
+      </values>
+    </entry>
   </entries>
 
 </compsets>


### PR DESCRIPTION
### Description of changes
Set LND_SETS_DUST_EMIS_DRV_FLDS.

### Specific notes
To avoid a conflict between CAM and CTSM dust emissions for B compsets, LND_SETS_DUST_EMIS_DRV_FLDS needs to be set.

Contributors other than yourself, if any:

Fixes: [Github issue #s] And brief description of each issue.

User interface changes?: [ No/Yes ] No
[ If yes, describe what changed, and steps taken to ensure backward compatibility ]

Testing performed (automated tests and/or manual tests):
SMS_Ld2.ne30pg3_t232.BLT1850.derecho_intel.allactive-defaultio

