### PR TITLE
Updates for cesm3_0_alpha04a tag.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,14 +66,14 @@
         url = https://github.com/ESCOMP/CTSM
         fxDONOTUSEurl = https://github.com/ESCOMP/CTSM
         fxrequired = ToplevelRequired
-        fxtag = ctsm5.3.002
+        fxtag = ctsm5.3.007
 
 [submodule "cice"]
         path = components/cice
         url = https://github.com/ESCOMP/CESM_CICE
         fxDONOTUSEurl = https://github.com/ESCOMP/CESM_CICE
         fxrequired = ToplevelRequired
-        fxtag = cesm_cice6_5_0_12
+        fxtag = cesm3_cice6_5_0_7
 
 [submodule "mom"]
         path = components/mom

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,83 @@
 ==============================================================
+Tag name: cesm3_0_alpha04a
+Originator(s): CSEG
+Date: 21st November 2024
+One-line Summary: Dust tunings and sea ice updates
+
+components/cam          https://github.com/ESCOMP/CAM/cam6_4_032                              --
+components/cice         https://github.com/ESCOMP/CESM_CICE/tree/cesm3_cice6_5_0_7            **
+cime                    https://github.com/ESMCI/cime/tree/cime6.1.29                         --
+share                   https://github.com/ESCOMP/CESM_share/tree/share1.1.2                  --
+ccs_config              https://github.com/ESMCI/ccs_config_cesm/tree/ccs_config_cesm1.0.7    --
+components/cmeps        https://github.com/ESCOMP/CMEPS/tree/cmeps1.0.16                      --
+components/cdeps        https://github.com/ESCOMP/CDEPS/tree/cdeps1.0.53                      --
+components/cism         https://github.com/ESCOMP/cism-wrapper/tree/cismwrap_2_2_002          --
+components/clm          https://github.com/ESCOMP/ctsm/tree/ctsm5.3.007                       **
+components/fms          https://github.com/ESCOMP/FMS_interface/tree/fi_240822                --
+components/mizuroute    https://github.com/ESCOMP/mizuRoute/tree/cesm-coupling.n02_v2.1.3     --
+components/mom          https://github.com/ESCOMP/MOM_interface/mi_240923                     --
+components/mosart       https://github.com/ESCOMP/mosart/tree/mosart1_1_02                    --
+components/rtm          https://github.com/ESCOMP/rtm/tree/rtm1_0_80                          --
+components/ww3          https://github.com/ESCOMP/WW3-CESM/tree/main_0.0.14                   --
+libraries/parallelio    https://github.com/NCAR/ParallilIO/tree/pio2_6_3                      --
+tools/CUPiD             https://github.com/NCAR/CUPiD/tree/v0.1.1                             --
+
+cice
+    David Bailey 2024-09-19 - cesm3_cice6_5_0_7 - components/cice (cesm3_0_alpha04a)
+    https://github.com/ESCOMP/CESM_CICE/tags/cesm3_cice6_5_0_3
+
+    This tag adds all of the new science capabilities for CICE. Several of these physics options
+    have been turned on by default along with a number of additional history variables. This is the
+    configuration of:
+
+    https://github.com/NCAR/cesm_dev/issues/14
+
+
+    I have mostly fixed the aux_cice testlist, but there is more to come here. I have also
+    updated the path for the MOM grid files.
+
+
+clm
+    Erik Kluzek 2024-10-08 - ctsm5.3.005 - components/clm (cesm3_0_alpha04a)
+    https://github.com/ESCOMP/ctsm/tags/ctsm5.3.X4
+
+    Dust tuning changes with clm6_0 physics. Dust emissions change when clm6_0 and Leung dust emission are on
+
+
+    Erik Kluzek 2024-10-10 - ctsm5.3.007 - components/clm (cesm3_0_alpha04a)
+    https://github.com/ESCOMP/ctsm/tags/ctsm5.3.007
+
+    Note
+    New IC files for clm6_0 for:
+
+    1850 ne30pg3, f09, f19
+    1979, 2000 ne30pg3 and f09
+
+
+    Erik Kluzek 2024-10-08 - ctsm5.3.006 - components/clm (cesm3_0_alpha04a)
+    https://github.com/ESCOMP/ctsm/tags/ctsm5.3.006
+
+    Bit-for-bit merge tag
+
+    Fixes a few issues from cesm3_0_beta03 tests
+    mksurfdata_esmf fix
+    Some shr_log fixes
+    Fix for some urban fields
+
+
+    Sam Rabin 2024-10-08 - ctsm5.3.004 - components/clm (cesm3_0_alpha04a)
+    https://github.com/ESCOMP/ctsm/tags/ctsm5.3.004
+
+    Move hillslope data off surface datasets
+
+
+    Erik Kluzek 2024-09-27 - ctsm5.3.003 - components/clm (cesm3_0_alpha04a)
+    https://github.com/ESCOMP/ctsm/tags/ctsm5.3.003
+
+    FATES parameter file update.
+
+
+==============================================================
 Tag name: cesm3_0_beta03
 Originator(s): CSEG
 Date: 3rdh Octobe 2024

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 ==============================================================
 Tag name: cesm3_0_alpha04a
 Originator(s): CSEG
-Date: 21st November 2024
+Date: 21st October 2024
 One-line Summary: Dust tunings and sea ice updates
 
 components/cam          https://github.com/ESCOMP/CAM/cam6_4_032                              --

--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -46,7 +46,7 @@
       <machine name="derecho" compiler="intel" category="prealpha"/>
     </machines>
     <options>
-      <option name="wallclock"> 01:00:00 </option>
+      <option name="wallclock"> 02:00:00 </option>
     </options>
   </test>
   <test name="SMS_Ld2" grid="ne30pg3_t232" compset="BLT1850" testmods="allactive/defaultio">
@@ -179,7 +179,7 @@
       <machine name="derecho" compiler="intel" category="prealpha"/>
     </machines>
     <options>
-      <option name="wallclock"> 01:00:00 </option>
+      <option name="wallclock"> 03:00:00 </option>
     </options>
   </test>
 </testlist>


### PR DESCRIPTION
### Description of changes
Update externals and ChangeLog for cesm3_0_alpha04a.
Increase wallclock for prealpha ERI tests on derecho.

