### PR TITLE
Github Action script to run preview_namelists

### DIFF
--- a/.github/workflows/preview_namelist.yaml
+++ b/.github/workflows/preview_namelist.yaml
@@ -1,0 +1,51 @@
+on:
+  push:
+    branches: [ master, cesm3.0-alphabranch ]
+  pull_request:
+    branches: [ master, cesm3.0-alphabranch ]
+
+jobs:
+  preview_namelists:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Lots of python versions, pare down if we don't support a version
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        config:
+          - {"compset": "BLT1850", "res": "ne30pg3_t232"} # fully coupled
+          - {"compset": "C_JRA", "res": "TL319_t232"}     # ocean only
+          - {"compset": "C1850MARBL_JRA", "res": "TL319_t232"}     # ocean only, with BGC
+          - {"compset": "DTEST", "res": "TL319_t232"}     # ice only
+          - {"compset": "I1850Clm60SpCru", "res": "f10_f10_mg37"} # land only
+          - {"compset": "QPC6HIST", "res": "f09_f09_mg17"} # atm only
+          - {"compset": "T1850Gg", "res": "f09_g17_gris4"} # glc only
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up non-python environment (need xmllint and a fake ESMF make file)
+        run: |
+          git config --global user.email "testing@github.actions"
+          git config --global user.name "Github Actions Testing"
+          echo "ESMFMKFILE=$HOME/esmf.mk" >> ${GITHUB_ENV}
+          echo "ESMF_VERSION_MAJOR=8" > ${HOME}/esmf.mk
+          echo "ESMF_VERSION_MINOR=8" >> ${HOME}/esmf.mk
+          sudo apt-get install libxml2-utils
+
+
+      - name: Checkout CESM
+        run: |
+          $GITHUB_WORKSPACE/bin/git-fleximod update
+
+      - name: Create new cases, run case.setup, and then preview namelists
+        run: |
+          cd $GITHUB_WORKSPACE/cime/scripts
+          ./create_newcase --run-unsupported --mach ubuntu-latest --compset ${{ matrix.config.compset }} --res ${{ matrix.config.res }} --case $GITHUB_WORKSPACE/cases/${{ matrix.config.compset }}_${{ matrix.python-version }}
+          cd $GITHUB_WORKSPACE/cases/${{ matrix.config.compset }}_${{ matrix.python-version }}
+          ./case.setup
+          ./preview_namelists

--- a/.github/workflows/preview_namelist.yaml
+++ b/.github/workflows/preview_namelist.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
### Description of changes

Adds Github Action to create cases using a range of compsets (currently `B`, `C`, `C` with MARBL, `D`, `I`, `Q`, and `T`) and run `preview_namelists`. I intentionally set up the matrix to turn this into 35 parallel jobs (7 compsets and 5 versions of python)... it might be more efficient to have a separate job for each version of python that creates all 7 compsets in that same job, but I think that would make it harder to parse the results. If a `B` compset is failing because of issues in MOM6, CAM, and CLM, then we should see failures in `B`, both `C`s, `I`, and `Q` tests while a single job per python version would just abort after the first failure and not catch the other four.

### Specific notes

Contributors other than yourself, if any: @manishvenu was helpful in getting past some issues I had with github actions

Fixes: [Github issue #s] And brief description of each issue.

User interface changes?: [ No/Yes ]
[ If yes, describe what changed, and steps taken to ensure backward compatibility ]

Testing performed (automated tests and/or manual tests): These tests have run on my branch at https://github.com/mnlevy1981/cesm/actions/runs/11946703920 -- note that I had 3.14 in the python version matrix, but those tests failed with

```
Version 3.14 was not found in the local cache
  Error: The version '3.14' with architecture 'x64' was not found for Ubuntu 22.04.
```

So I removed it from this PR. Test results:

* Fails in python 3.9 for G and B compsets because CICE's `buildnml` relies on `glob.glob` API introduced in 3.10
* Fails all 3.12 and 3.13 tests because `distutils` has been removed from the standard library

