### PR TITLE
Revert cice tag and update compsets.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,7 +73,7 @@
         url = https://github.com/ESCOMP/CESM_CICE
         fxDONOTUSEurl = https://github.com/ESCOMP/CESM_CICE
         fxrequired = ToplevelRequired
-        fxtag = cesm_cice6_6_0_1
+        fxtag = cesm3_cice6_5_0_15
 
 [submodule "mom"]
         path = components/mom

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -40,59 +40,72 @@
 
   <compset>
     <alias>B1850C_MTt4s</alias>
-    <lname>1850C_CAM70%MT%CT4S_CLM60%BGC-CROP_CICE_MOM6%MARBL-BIO_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>1850C_CAM70%MT%CT4S_CLM60%BGC-CROP_CICE_MOM6_DGLC%NOEVOLVE_WW3</lname>
   </compset>
   <compset>
     <alias>B1850CM</alias>
-    <lname>1850C_CAM70%MT%CT4S_CLM60%BGC-CROP_CICE_MOM6%MARBL-BIO_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>1850C_CAM70%MT%CT4S_CLM60%BGC-CROP_CICE_MOM6_DGLC%NOEVOLVE_WW3</lname>
   </compset>
 
 
   <compset>
     <alias>B1850C_MTso</alias>
-    <lname>1850C_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6%MARBL-BIO_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>1850C_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6_DGLC%NOEVOLVE_WW3</lname>
   </compset>
+
   <compset>
     <alias>BMT1850</alias>
-    <lname>1850C_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6%MARBL-BIO_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>1850C_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6_DGLC%NOEVOLVE_WW3</lname>
   </compset>
+
+  <compset>
+    <alias>BMT1850_MARBL</alias>
+    <lname>1850_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6%MARBL-BIO_MOSART_DGLC%NOEVOLVE_SWAV</lname>
+  </compset>
+
   <compset>
     <alias>BHISTC_MTso</alias>
-    <lname>HISTC_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6%MARBL-BIO_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>HISTC_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6_DGLC%NOEVOLVE_WW3</lname>
   </compset>
 
   <compset>
     <alias>BHISTC_MTt4s</alias>
-    <lname>HISTC_CAM70%MT%CT4S_CLM60%BGC-CROP_CICE_MOM6%MARBL-BIO_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>HISTC_CAM70%MT%CT4S_CLM60%BGC-CROP_CICE_MOM6_DGLC%NOEVOLVE_WW3</lname>
   </compset>
   <compset>
     <alias>BHISTCM</alias>
-    <lname>HISTC_CAM70%MT%CT4S_CLM60%BGC-CROP_CICE_MOM6%MARBL-BIO_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>HISTC_CAM70%MT%CT4S_CLM60%BGC-CROP_CICE_MOM6_DGLC%NOEVOLVE_WW3</lname>
   </compset>
 
 
   <compset>
     <alias>B1850C_LTso</alias>
-    <lname>1850C_CAM70%LT_CLM60%BGC-CROP_CICE_MOM6%MARBL-BIO_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>1850C_CAM70%LT_CLM60%BGC-CROP_CICE_MOM6_DGLC%NOEVOLVE_WW3</lname>
   </compset>
   <compset>
     <alias>BLT1850</alias>
-    <lname>1850C_CAM70%LT_CLM60%BGC-CROP_CICE_MOM6%MARBL-BIO_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>1850C_CAM70%LT_CLM60%BGC-CROP_CICE_MOM6_DGLC%NOEVOLVE_WW3</lname>
   </compset>
+
+  <compset>
+    <alias>BLT1850_MARBL</alias>
+    <lname>1850_CAM70%LT_CLM60%BGC-CROP_CICE_MOM6%MARBL-BIO_MOSART_DGLC%NOEVOLVE_SWAV</lname>
+  </compset>
+
   <compset>
     <alias>BHISTC_LTso</alias>
-    <lname>HISTC_CAM70%LT_CLM60%BGC-CROP_CICE_MOM6%MARBL-BIO_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>HISTC_CAM70%LT_CLM60%BGC-CROP_CICE_MOM6_DGLC%NOEVOLVE_WW3</lname>
   </compset>
 
   <!-- Emissions driven compsets for CESM3 -->
 
   <compset>
     <alias>B1850E_MTt4s</alias>
-    <lname>1850E_CAM70%MT%CT4S_CLM60%BGC-CROP_CICE_MOM6%MARBL-BIO_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>1850E_CAM70%MT%CT4S_CLM60%BGC-CROP_CICE_MOM6_DGLC%NOEVOLVE_WW3</lname>
   </compset>
   <compset>
     <alias>B1850EM</alias>
-    <lname>1850E_CAM70%MT%CT4S_CLM60%BGC-CROP_CICE_MOM6%MARBL-BIO_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>1850E_CAM70%MT%CT4S_CLM60%BGC-CROP_CICE_MOM6_DGLC%NOEVOLVE_WW3</lname>
   </compset>
 
   <!-- SOM compsets -->


### PR DESCRIPTION
Remove MARBL from fully coupled compsets, and add back MARBL specific compsets.
Backup cice tag to version that works with CAM due to issue https://github.com/ESCOMP/CICE/issues/36

