### PR TITLE
Add git diff to fleximod_test

### DIFF
--- a/.github/workflows/fleximod_test.yaml
+++ b/.github/workflows/fleximod_test.yaml
@@ -7,6 +7,7 @@ jobs:
   fleximod-test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         # oldest supported and latest supported
         python-version: ["3.7", "3.x"]

--- a/.github/workflows/fleximod_test.yaml
+++ b/.github/workflows/fleximod_test.yaml
@@ -20,8 +20,12 @@ jobs:
           echo "Update complete, checking status"
           echo
           $GITHUB_WORKSPACE/bin/git-fleximod test
+      - id: check-cleanliness
+        run: |
+          echo
+          echo "Checking if git fleximod matches expected externals"
+          echo
+          git diff --exit-code
 #      - name: Setup tmate session
 #        if: ${{ failure() }}
 #        uses: mxschmitt/action-tmate@v3
-        
-          

--- a/.gitmodules
+++ b/.gitmodules
@@ -80,7 +80,7 @@
         url = https://github.com/ESCOMP/MOM_interface
         fxDONOTUSEurl = https://github.com/ESCOMP/MOM_interface
         fxrequired = ToplevelRequired
-        fxtag = mi_250128
+        fxtag = mi_250210
 
 [submodule "cism"]
         path = components/cism


### PR DESCRIPTION
### Description of changes
If the tags used by git fleximod in the `.gitmodules` do not match the externals checked in to the various components, then `git diff --exit-code` will fail. In this case, whichever components are triggering the failure should be updated to ensure `.gitmodules` and the actual externals match.

### Specific notes

Contributors other than yourself, if any:

Fixes: [Github issue #s] And brief description of each issue.

User interface changes?: No

Testing performed (automated tests and/or manual tests):

I verified that `git diff --exit-code` will return 1 if there are differences in any of the submodules (including differences in submodules of submodules) and 0 if everything is clean; I'm 99% sure this branch will fail the fleximod-test for non-zero return codes.