### PR TITLE
Update to mpas-ocean tag mpaso-ew2.5.006

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -116,7 +116,7 @@
         url = https://github.com/EarthWorksOrg/mpas-ocean.git
         fxDONOTUSEurl = https://github.com/EarthWorksOrg/mpas-ocean.git
         fxrequired = ToplevelRequired
-        fxtag = mpaso-ew2.5.005
+        fxtag = mpaso-ew2.5.006
 
 [submodule "mpas-seaice"]
         path = components/mpas-seaice


### PR DESCRIPTION
Updating to mpas-ocean tag mpaso-ew2.5.006, with new cvmix v1.0.0 submodule, and disabled GOTM

These changes do not alter model solution.

Build and simulation have been verified with one month simulation of DATM/MPASO/MPASSI at 120km

