### PR TITLE
Change long name specifier for CO2 forcings

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -134,12 +134,12 @@
   <entries>
     <entry id="RUN_STARTDATE">
       <values>
-	<value compset="1850[CE]?_"     >0001-01-01</value>
-	<value compset="2000[CE]?_"     >0001-01-01</value>
-	<value compset="HIST[CE]?_"     >1850-01-01</value>
-	<value compset="5505[CE]?_"     >1955-01-01</value>
-	<value compset="RCP[2468][CE]?_">2005-01-01</value>
-	<value compset="2013[CE]?_"     >2013-01-01</value>
+	<value compset="1850_"     >0001-01-01</value>
+	<value compset="2000_"     >0001-01-01</value>
+	<value compset="HIST_"     >1850-01-01</value>
+	<value compset="5505_"     >1955-01-01</value>
+	<value compset="RCP[2468]_">2005-01-01</value>
+	<value compset="2013_"     >2013-01-01</value>
       </values>
     </entry>
     <entry id="LND_SETS_DUST_EMIS_DRV_FLDS">

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -40,83 +40,83 @@
 
   <compset>
     <alias>B1850C_MTt4s</alias>
-    <lname>1850C_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>1850_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
   </compset>
   <compset>
     <alias>B1850CM</alias>
-    <lname>1850C_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>1850_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>B1850C_MTso</alias>
-    <lname>1850C_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>1850_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>BHISTC_MTso</alias>
-    <lname>HISTC_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>HIST_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>BHISTC_MTt4s</alias>
-    <lname>HISTC_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>HIST_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>BHISTCM</alias>
-    <lname>HISTC_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>HIST_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>BHISTC_MTso</alias>
-    <lname>HISTC_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>HIST_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
   </compset>
 <!--  Not yet available in cam component
   <compset>
     <alias>B1850C_WAt4ma</alias>
-    <lname>1850C_CAM70%HT%CT4MA_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>1850_CAM70%HT%CT4MA_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>BHISTC_WAt4ma</alias>
-    <lname>1850_CAM70%HT%CT4MA_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_SWAV</lname>
+    <lname>1850_CAM70%HT%CT4MA_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_SWAV_BGC%BDRD</lname>
   </compset>
 -->
   <compset>
     <alias>B1850C_LTso</alias>
-    <lname>1850C_CAM70%LT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>1850_CAM70%LT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>BHISTC_LTso</alias>
-    <lname>HISTC_CAM70%LT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>HIST_CAM70%LT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
   </compset>
 
   <!-- BHIST_LTso, except: WW3 can't handle multi-instance (2026-3), 
        CROP doesn't work in this context. -->
   <compset>
     <alias>BHISTC_LT_DART</alias>
-    <lname>HISTC_CAM70%LT_CLM60%BGC_CICE_MOM6_MOSART_DGLC%NOEVOLVE_SWAV</lname>
+    <lname>HIST_CAM70%LT_CLM60%BGC_CICE_MOM6_MOSART_DGLC%NOEVOLVE_SWAV_BGC%BDRD</lname>
   </compset>
 
   <!-- Emissions driven compsets for CESM3 -->
 
   <compset>
     <alias>B1850E_MTt4s</alias>
-    <lname>1850E_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>1850_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BPRP</lname>
   </compset>
   <compset>
     <alias>B1850EM</alias>
-    <lname>1850E_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>1850_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BPRP</lname>
   </compset>
   
   <compset>
     <alias>BHISTE_MTt4s</alias>
-    <lname>HISTE_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>HIST_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BPRP</lname>
   </compset>
   <compset>
     <alias>BHISTEM</alias>
-    <lname>HISTE_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
+    <lname>HIST_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BPRP</lname>
   </compset>
 
   <!-- SOM compsets -->

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -40,63 +40,63 @@
 
   <compset>
     <alias>B1850C_MTt4s</alias>
-    <lname>1850_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <lname>1850_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
   </compset>
   <compset>
     <alias>B1850CM</alias>
-    <lname>1850_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <lname>1850_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
   </compset>
 
   <compset>
     <alias>B1850C_MTso</alias>
-    <lname>1850_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <lname>1850_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
   </compset>
 
   <compset>
     <alias>BHISTC_MTso</alias>
-    <lname>HIST_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <lname>HIST_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
   </compset>
 
   <compset>
     <alias>BHISTC_MTt4s</alias>
-    <lname>HIST_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <lname>HIST_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
   </compset>
 
   <compset>
     <alias>BHISTCM</alias>
-    <lname>HIST_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <lname>HIST_CAM70%MT%CT4S2_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
   </compset>
 
   <compset>
     <alias>BHISTC_MTso</alias>
-    <lname>HIST_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <lname>HIST_CAM70%MT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
   </compset>
 <!--  Not yet available in cam component
   <compset>
     <alias>B1850C_WAt4ma</alias>
-    <lname>1850_CAM70%HT%CT4MA_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <lname>1850_CAM70%HT%CT4MA_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
   </compset>
 
   <compset>
     <alias>BHISTC_WAt4ma</alias>
-    <lname>1850_CAM70%HT%CT4MA_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_SWAV_BGC%BDRD</lname>
+    <lname>1850_CAM70%HT%CT4MA_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_SWAV</lname>
   </compset>
 -->
   <compset>
     <alias>B1850C_LTso</alias>
-    <lname>1850_CAM70%LT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <lname>1850_CAM70%LT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
   </compset>
 
   <compset>
     <alias>BHISTC_LTso</alias>
-    <lname>HIST_CAM70%LT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <lname>HIST_CAM70%LT_CLM60%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_WW3</lname>
   </compset>
 
   <!-- BHIST_LTso, except: WW3 can't handle multi-instance (2026-3), 
        CROP doesn't work in this context. -->
   <compset>
     <alias>BHISTC_LT_DART</alias>
-    <lname>HIST_CAM70%LT_CLM60%BGC_CICE_MOM6_MOSART_DGLC%NOEVOLVE_SWAV_BGC%BDRD</lname>
+    <lname>HIST_CAM70%LT_CLM60%BGC_CICE_MOM6_MOSART_DGLC%NOEVOLVE_SWAV</lname>
   </compset>
 
   <!-- Emissions driven compsets for CESM3 -->


### PR DESCRIPTION
### Description of changes

We have decided to use the CESM2 scheme for this.

See https://github.com/ESCOMP/CMEPS/pull/658 for some relevant discussion.

I did this with two regex search & replaces:

(1) Concentration-driven:
- Search for `<lname>([^_]*)C_(.*)</lname>`
- Replace with `<lname>$1_$2_BGC%BDRD</lname>`
- Update 2026-06-18: we later decided to remove the `_BGC%BDRD` from these compsets

(2) Emissions-driven:
- Search for `<lname>([^_]*)E_(.*)</lname>`
- Replace with `<lname>$1_$2_BGC%BPRP</lname>`

**This should be coordinated with the following component changes:**
- **This should come in at the same time as the CAM PR that changes compsets similarly: https://github.com/ESCOMP/CAM/pull/1584**
- Ideally, [this CTSM PR](https://github.com/ESCOMP/CTSM/pull/4097) and [this CDEPS PR](https://github.com/ESCOMP/CDEPS/pull/413) would come in at the same time. However, it's safe for either or both of them to come later. (The reason that it's ideal for them to come in at the same time is just to ensure that they are bit-for-bit across a wide range of configurations - so it would be ideal to include them in the bit-for-bit prealpha testing that is planned for this PR.)
- For emissions-driven compsets to work correctly, this also needs the changes in [this CAM PR](https://github.com/ESCOMP/CAM/pull/1581); however, emissions-driven compsets currently aren't tested, so it's safe for that CAM PR to come in later

### Specific notes

Contributors other than yourself, if any: none

Fixes: none

User interface changes?: No

**Expected answer changes:** Bit-for-bit for concentration-driven compsets (which are the only ones currently tested). (`B1850E*` and `BHISTE*` compsets would change answers, but we currently don't test them.)

Testing performed (automated tests and/or manual tests):

Ran these tests; they pass and are bit-for-bit:
- ERS_Ld5.ne30pg3_t232.B1850C_LTso.derecho_intel.allactive-defaultio
- ERS_Ld5.ne30pg3_t232.BHISTC_LTso.derecho_intel.allactive-defaultio
- ERS_D_Ld3.ne30pg3_t232.B1850C_LTso.derecho_intel.allactive-defaultio