### PR TITLE
Remove unnecessary testmod setting

### DIFF
--- a/cime_config/testmods_dirs/allactive/cism/test_coupling/user_nl_clm
+++ b/cime_config/testmods_dirs/allactive/cism/test_coupling/user_nl_clm
@@ -2,11 +2,3 @@
  ! This is needed to tell CLM to allow the non-annual-boundary glacier changes that arise
  ! with this testmod.
  for_testing_allow_non_annual_changes = .true.
-
- ! When we have daily rather than annual glacier dynamics (as we do in this testmod, due
- ! to having test_coupling in user_nl_cism), CLM applies the dynbal adjustments in a
- ! single time step rather than spreading them throughout the year. This can cause
- ! sensible heat fluxes of thousands of W m-2, which causes CAM's PBL scheme to blow up.
- ! So force these fluxes to zero for this testmod; this breaks water and energy
- ! conservation in CLM, but should allow the test to pass.
- for_testing_zero_dynbal_fluxes = .true.


### PR DESCRIPTION
### Description of changes

This will be unnecessary following
https://github.com/ESCOMP/CTSM/pull/4189. This testmod is currently
unused, so it seems safe to bring this in even before that CTSM PR is
merged, since the plan is to merge that PR soon.

### Specific notes

Contributors other than yourself, if any: N/A

Fixes: N/A

User interface changes?: No

Testing performed (automated tests and/or manual tests): None

