### PR TITLE
Update pe layouts

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -117,12 +117,12 @@
 	<comment></comment>
 	<ntasks>
 	  <ntasks_atm>5400</ntasks_atm>
-	  <ntasks_lnd>1792</ntasks_lnd>
-	  <ntasks_rof>1792</ntasks_rof>
-	  <ntasks_ice>3608</ntasks_ice>
-	  <ntasks_ocn>3300</ntasks_ocn>
-	  <ntasks_glc>4</ntasks_glc>
-	  <ntasks_wav>64</ntasks_wav>
+	  <ntasks_lnd>5400</ntasks_lnd>
+	  <ntasks_rof>104</ntasks_rof>
+	  <ntasks_ice>5400</ntasks_ice>
+	  <ntasks_ocn>2560</ntasks_ocn>
+	  <ntasks_glc>104</ntasks_glc>
+	  <ntasks_wav>104</ntasks_wav>
 	  <ntasks_cpl>5400</ntasks_cpl>
 	</ntasks>
 	<nthrds>
@@ -138,9 +138,9 @@
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
 	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>1792</rootpe_ice>
-	  <rootpe_ocn>5404</rootpe_ocn>
+	  <rootpe_rof>5400</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>5504</rootpe_ocn>
 	  <rootpe_glc>5400</rootpe_glc>
 	  <rootpe_wav>5400</rootpe_wav>
 	  <rootpe_cpl>0</rootpe_cpl>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -40,7 +40,7 @@
     </mach>
   </grid>
 
-  <grid name="a%ne30np4.pg3_l%ne30np4.pg3_oi%tx2_3v2">
+  <grid name="a%ne30np4.pg3_l%ne30np4.pg3_oi%tx2_3v[23]">
     <mach name="derecho">
       <pes pesize="M" compset="CAM.*%MT.*MOM6(?!.*%MARBL-BIO)">
 	<comment></comment>
@@ -111,7 +111,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne30np4.pg3_l%ne30np4.pg3_oi%tx2_3v2">
+  <grid name="a%ne30np4.pg3_l%ne30np4.pg3_oi%tx2_3v[23]">
     <mach name="derecho">
       <pes pesize="M" compset="CAM.*%MT.*MOM6%[^_]*MARBL-BIO">
 	<comment></comment>
@@ -413,7 +413,7 @@
 	</pes>
       </mach>
     </grid>
-    <grid name="a%ne30np4.pg3_l%ne30np4.pg3_oi%tx2_3v2">
+    <grid name="a%ne30np4.pg3_l%ne30np4.pg3_oi%tx2_3v[23]">
       <mach name="any">
         <pes pesize="M" compset="CAM.*%MT.*MOM6">
           <CAM_CONFIG_OPTS append="True">'-pcols 9'</CAM_CONFIG_OPTS>


### PR DESCRIPTION
### Description of changes
Support `tx2_3v3` grid for out-of-the-box layouts, and improve the MT+MARBL layout to match current development runs

Fixes #422 
Fixes #423 

User interface changes?: No

Testing performed (automated tests and/or manual tests): I created a new case with `ne30pg3_t233_wg37_gris4` grid and verified `env_run.xml` is the same (modulo a `<comment>` line) as `env_mach_pes.xml` in run 377.

```
$ diff -u  /glade/campaign/cesm/cesmdata/cseg/runs/cesm2_0/b.e30_alpha09d_m.B1850C_MTso_Gris_Marbl.ne30_t233_wgx3.377/env_mach_pes.xml .
--- /glade/campaign/cesm/cesmdata/cseg/runs/cesm2_0/b.e30_alpha09d_m.B1850C_MTso_Gris_Marbl.ne30_t233_wgx3.377/env_mach_pes.xml	2026-08-09 15:06:18.100389000 -0600
+++ ./env_mach_pes.xml	2026-09-08 17:19:35.019982879 -0600
@@ -24,7 +24,6 @@
     The following values should not be set by the user since they'll be
     overwritten by scripts: TOTALPES, NTASKS_PER_INST
     </header>
-  <comment>none</comment>
   <group id="mach_pes">
     <entry id="ESMF_AWARE_THREADING" value="FALSE">
       <type>logical</type>

```

